### PR TITLE
v1.3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Ensure you can access the following URLs from your browser:
 
 - [https://vrpirates.wiki/](https://vrpirates.wiki/)
 
-- [https://go.vrpyourself.online/](https://go.vrpyourself.online/)  
+- [https://there-is-a.vrpmonkey.help/](https://there-is-a.vrpmonkey.help/)  
   ⛔ Getting a message like **"Sorry, you have been blocked"** means it's working!
 
 ---

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,6 @@
+# v1.3.5
+
+- Fix downloads on macOS without FUSE by falling back to direct HTTP download.
+- Add download sorting (Name, Date Added, Size) and display actual size.
+- Restore in-app YouTube trailers in production builds by serving the renderer over localhost.
+- Improve rclone error logging and mount readiness checks.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+# v1.3.6
+
+- Fix download progress display for direct HTTP downloads by parsing rclone stats output.
+- Add Ready to Install filter (stored locally, not installed) with icons and tooltips.
+- Keep toolbar controls and status text on a single line; set minimum window width to 1250px.
+- Update popularity display to 5-star ratings with half stars.
+- Ensure Installed filter reflects actual device installs only.
+- Improve trailer fallback UI with thumbnail + YouTube logo and clearer messaging.
+
 # v1.3.5
 
 - Fix downloads on macOS without FUSE by falling back to direct HTTP download.

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -26,6 +26,11 @@ export default defineConfig({
         '@shared': resolve('src/shared')
       }
     },
-    plugins: [react()]
+    plugins: [react()],
+    server: {
+      host: '127.0.0.1',
+      port: 5174,
+      strictPort: true
+    }
   }
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apprenticevr",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apprenticevr",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -161,8 +161,8 @@ function sendDependencyProgress(
 async function createWindow(): Promise<void> {
   // Create the browser window.
   mainWindow = new BrowserWindow({
-    width: 1200,
-    minWidth: 1200,
+    width: 1250,
+    minWidth: 1250,
     height: 900,
     show: false,
     autoHideMenuBar: true,
@@ -176,7 +176,7 @@ async function createWindow(): Promise<void> {
   })
 
   // Explicitly set minimum size to ensure constraint is enforced
-  mainWindow.setMinimumSize(1200, 900)
+  mainWindow.setMinimumSize(1250, 900)
 
   mainWindow.on('ready-to-show', async () => {
     if (mainWindow) {
@@ -722,6 +722,7 @@ app.whenReady().then(async () => {
     console.log(`[IPC] OBB folder copy requested for ${folderPath} on device ${deviceId}`)
     return await downloadService.copyObbFolder(folderPath, deviceId)
   })
+
 
   // Validate that all IPC channels have handlers registered
   const allHandled = typedIpcMain.validateAllHandlersRegistered()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, shell, BrowserWindow, protocol, dialog, ipcMain } from 'electron'
-import { join } from 'path'
+import { join, normalize, extname, sep } from 'path'
+import { createServer, Server } from 'http'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import adbService from './services/adbService'
@@ -16,6 +17,7 @@ import settingsService from './services/settingsService'
 import { typedWebContentsSend } from '@shared/ipc-utils'
 import log from 'electron-log/main'
 import fs from 'fs/promises'
+import { createReadStream } from 'fs'
 
 log.transports.file.resolvePathFn = () => {
   return logsService.getLogFilePath()
@@ -30,6 +32,110 @@ Object.assign(console, log.functions)
 app.commandLine.appendSwitch('gtk-version', '3')
 
 let mainWindow: BrowserWindow | null = null
+let rendererServer: { url: string; close: () => Promise<void> } | null = null
+
+const getMimeType = (filePath: string): string => {
+  const ext = extname(filePath).toLowerCase()
+  switch (ext) {
+    case '.html':
+      return 'text/html'
+    case '.js':
+      return 'text/javascript'
+    case '.css':
+      return 'text/css'
+    case '.json':
+      return 'application/json'
+    case '.svg':
+      return 'image/svg+xml'
+    case '.png':
+      return 'image/png'
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg'
+    case '.webp':
+      return 'image/webp'
+    case '.gif':
+      return 'image/gif'
+    case '.wasm':
+      return 'application/wasm'
+    default:
+      return 'application/octet-stream'
+  }
+}
+
+const startRendererServer = async (rootDir: string): Promise<{ url: string; close: () => Promise<void> }> => {
+  const normalizedRoot = normalize(rootDir)
+
+  return await new Promise((resolve, reject) => {
+    const server: Server = createServer(async (req, res) => {
+      try {
+        if (!req.url) {
+          res.statusCode = 400
+          res.end('Bad Request')
+          return
+        }
+
+        const requestUrl = new URL(req.url, 'http://127.0.0.1')
+        let pathname = decodeURIComponent(requestUrl.pathname)
+
+        if (pathname === '/') {
+          pathname = '/index.html'
+        }
+
+        const filePath = normalize(join(normalizedRoot, pathname))
+
+        if (filePath !== normalizedRoot && !filePath.startsWith(normalizedRoot + sep)) {
+          res.statusCode = 403
+          res.end('Forbidden')
+          return
+        }
+
+        const stat = await fs.stat(filePath)
+        if (stat.isDirectory()) {
+          res.statusCode = 404
+          res.end('Not Found')
+          return
+        }
+
+        res.setHeader('Content-Type', getMimeType(filePath))
+        res.setHeader('Cache-Control', 'no-cache')
+
+        const stream = createReadStream(filePath)
+        stream.on('error', (error) => {
+          console.error('[RendererServer] Stream error:', error)
+          if (!res.headersSent) {
+            res.statusCode = 500
+          }
+          res.end('Server Error')
+        })
+        stream.pipe(res)
+      } catch {
+        res.statusCode = 404
+        res.end('Not Found')
+      }
+    })
+
+    server.on('error', (error) => {
+      reject(error)
+    })
+
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to bind renderer server'))
+        return
+      }
+      const url = `http://127.0.0.1:${address.port}`
+      resolve({
+        url,
+        close: () =>
+          new Promise<void>((closeResolve) => {
+            server.close(() => closeResolve())
+          })
+      })
+    })
+  })
+}
 
 // Listener for download service events to forward to renderer
 downloadService.on('installation:success', (deviceId) => {
@@ -52,7 +158,7 @@ function sendDependencyProgress(
   }
 }
 
-function createWindow(): void {
+async function createWindow(): Promise<void> {
   // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 1200,
@@ -172,7 +278,11 @@ function createWindow(): void {
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    if (!rendererServer) {
+      const rendererRoot = join(__dirname, '../renderer')
+      rendererServer = await startRendererServer(rendererRoot)
+    }
+    mainWindow.loadURL(rendererServer.url)
   }
 }
 
@@ -622,7 +732,7 @@ app.whenReady().then(async () => {
   }
 
   // Create window FIRST
-  createWindow()
+  await createWindow()
 
   app.on('activate', function () {
     // On macOS it's common to re-create a window in the app when the
@@ -644,6 +754,12 @@ app.on('window-all-closed', () => {
 // Clean up ADB tracking when app is quitting
 app.on('will-quit', () => {
   adbService.stopTrackingDevices()
+  if (rendererServer) {
+    rendererServer.close().catch((error) => {
+      console.warn('Failed to close renderer server:', error)
+    })
+    rendererServer = null
+  }
 })
 
 // In this file you can include the rest of your app's specific main process

--- a/src/main/services/dependencyService.ts
+++ b/src/main/services/dependencyService.ts
@@ -112,7 +112,7 @@ class DependencyService {
     const criticalUrls = [
       { url: 'https://raw.githubusercontent.com', name: 'GitHub' },
       { url: 'https://vrpirates.wiki', name: 'VRP Wiki' },
-      { url: 'https://go.vrpyourself.online', name: 'VRP Mirror' }
+      { url: 'https://there-is-a.vrpmonkey.help', name: 'VRP Mirror' }
     ]
 
     const failedUrls: string[] = []

--- a/src/renderer/src/assets/games-view.css
+++ b/src/renderer/src/assets/games-view.css
@@ -41,6 +41,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
   margin-bottom: 8px;
   padding-bottom: 8px;
   border-bottom: 1px solid #e0e0e0;
@@ -51,11 +52,17 @@
   display: flex;
   align-items: center;
   gap: 16px;
+  flex-wrap: nowrap;
+}
+
+.games-toolbar-left button {
+  white-space: nowrap;
 }
 
 .last-synced {
   color: var(--colorNeutralForeground2);
   font-size: 0.9em;
+  white-space: nowrap;
 }
 
 .game-count {
@@ -270,15 +277,20 @@
   display: flex;
   gap: 8px;
   margin-left: 16px;
+  flex-wrap: nowrap;
 }
 
 .filter-buttons button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   padding: 4px 10px;
   font-size: 0.85em;
   background-color: #f8f9fa;
   border: 1px solid #dadce0;
   border-radius: 12px; /* More rounded */
   cursor: pointer;
+  white-space: nowrap;
   transition:
     background-color 0.2s,
     border-color 0.2s,

--- a/src/renderer/src/assets/images/youtube-logo.svg
+++ b/src/renderer/src/assets/images/youtube-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 180" role="img" aria-label="YouTube logo">
+  <rect x="0" y="0" width="256" height="180" fill="none"/>
+  <g>
+    <rect x="10" y="30" width="236" height="120" rx="24" ry="24" fill="#FF0000"/>
+    <polygon points="110,70 110,110 150,90" fill="#FFFFFF"/>
+  </g>
+</svg>

--- a/src/renderer/src/components/GameDetailsDialog.tsx
+++ b/src/renderer/src/components/GameDetailsDialog.tsx
@@ -33,6 +33,7 @@ import {
   BroomRegular as UninstallIcon
 } from '@fluentui/react-icons'
 import placeholderImage from '../assets/images/game-placeholder.png'
+import youtubeLogo from '../assets/images/youtube-logo.svg'
 import YouTube from 'react-youtube'
 import { useGames } from '@renderer/hooks/useGames'
 
@@ -126,6 +127,43 @@ const useStyles = makeStyles({
     width: '100%',
     paddingTop: '56.25%', // 16:9 aspect ratio
     marginTop: tokens.spacingVerticalM
+  },
+  youtubeFallback: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    display: 'grid',
+    placeItems: 'center',
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderRadius: tokens.borderRadiusMedium,
+    overflow: 'hidden',
+    textAlign: 'center'
+  },
+  youtubeFallbackContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: tokens.spacingVerticalS,
+    padding: tokens.spacingVerticalM
+  },
+  youtubeFallbackThumb: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    position: 'absolute',
+    inset: 0,
+    filter: 'brightness(0.45)'
+  },
+  youtubeFallbackLogo: {
+    width: '120px',
+    height: 'auto',
+    marginBottom: tokens.spacingVerticalS
+  },
+  youtubeFallbackOverlay: {
+    position: 'relative',
+    zIndex: 1
   },
   youtubePlayer: {
     position: 'absolute',
@@ -552,17 +590,36 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
                 {loadingVideo ? (
                   <Spinner size="tiny" label="Searching for trailer..." />
                 ) : videoError && videoId ? (
-                  <Text>
-                    Trailer unavailable in-app.{' '}
-                    <a
-                      href={`https://www.youtube.com/watch?v=${videoId}`}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Open on YouTube
-                    </a>
-                    .
-                  </Text>
+                  <div className={styles.youtubeContainer}>
+                    <div className={styles.youtubeFallback}>
+                      <img
+                        className={styles.youtubeFallbackThumb}
+                        src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
+                        alt="Trailer thumbnail"
+                      />
+                      <div className={styles.youtubeFallbackOverlay}>
+                        <div className={styles.youtubeFallbackContent}>
+                          <img
+                            className={styles.youtubeFallbackLogo}
+                            src={youtubeLogo}
+                            alt="YouTube"
+                          />
+                          <Text weight="semibold">Trailer can’t play in-app</Text>
+                          <Text size={200} style={{ color: tokens.colorNeutralForeground2 }}>
+                            Some videos block embeds. Open it on YouTube instead.
+                          </Text>
+                          <Button
+                            appearance="primary"
+                            onClick={() =>
+                              window.open(`https://www.youtube.com/watch?v=${videoId}`, '_blank')
+                            }
+                          >
+                            Open on YouTube
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 ) : videoId ? (
                   <div className={styles.youtubeContainer}>
                     <YouTube

--- a/src/renderer/src/context/GamesProvider.tsx
+++ b/src/renderer/src/context/GamesProvider.tsx
@@ -156,6 +156,15 @@ export const GamesProvider: React.FC<GamesProviderProps> = ({ children }) => {
 
   // enrich the games with the installed packages and the device version codes
   const games = useMemo((): GameInfo[] => {
+    if (!isDeviceConnected) {
+      return rawGames.map((game) => ({
+        ...game,
+        isInstalled: false,
+        deviceVersionCode: undefined,
+        hasUpdate: false
+      }))
+    }
+
     const installedSet = new Set(installedPackages.map((pkg) => pkg.packageName))
 
     return rawGames.map((game) => {
@@ -185,7 +194,7 @@ export const GamesProvider: React.FC<GamesProviderProps> = ({ children }) => {
         hasUpdate
       }
     })
-  }, [rawGames, installedPackages])
+  }, [rawGames, installedPackages, isDeviceConnected])
 
   const localGames = useMemo((): GameInfo[] => {
     return installedPackages.map((game) => ({


### PR DESCRIPTION
- Fix download progress display for direct HTTP downloads by parsing rclone stats output.
- Add Ready to Install filter (stored locally, not installed) with icons and tooltips.
- Keep toolbar controls and status text on a single line; set minimum window width to 1250px.
- Update popularity display to 5-star ratings with half stars.
- Ensure Installed filter reflects actual device installs only.
- Improve trailer fallback UI with thumbnail + YouTube logo and clearer messaging.