### PR TITLE
v1.3.6 various improvements and polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Ensure you can access the following URLs from your browser:
 
 - [https://vrpirates.wiki/](https://vrpirates.wiki/)
 
-- [https://go.vrpyourself.online/](https://go.vrpyourself.online/)  
+- [https://there-is-a.vrpmonkey.help/](https://there-is-a.vrpmonkey.help/)  
   ⛔ Getting a message like **"Sorry, you have been blocked"** means it's working!
 
 ---

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,6 @@
+# v1.3.5
+
+- Fix downloads on macOS without FUSE by falling back to direct HTTP download.
+- Add download sorting (Name, Date Added, Size) and display actual size.
+- Restore in-app YouTube trailers in production builds by serving the renderer over localhost.
+- Improve rclone error logging and mount readiness checks.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,12 @@
+# v1.3.6
+
+- Fix download progress display for direct HTTP downloads by parsing rclone stats output.
+- Add Ready to Install filter (stored locally, not installed) with icons and tooltips.
+- Keep toolbar controls and status text on a single line; set minimum window width to 1250px.
+- Update popularity display to 5-star ratings with half stars.
+- Ensure Installed filter reflects actual device installs only.
+- Improve trailer fallback UI with thumbnail + YouTube logo and clearer messaging.
+
 # v1.3.5
 
 - Fix downloads on macOS without FUSE by falling back to direct HTTP download.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+# v1.3.8
+
+- Improve direct-download reliability with stronger rclone retry/timeout settings and safer transfer concurrency.
+- Apply configured download speed limits to direct rclone downloads as bandwidth limits.
+- Add adaptive stall detection windows for public downloads to reduce false-positive stall failures.
+- Fix retry behavior for `InstallError` items to reuse existing local payloads instead of forcing re-download.
+- Improve update fallback flow when completed queue entries are missing by automatically re-queuing download.
+- Add `Download Only` action for installed titles from the game details dialog.
+- Add FUSE diagnostics in Settings with status check, installer shortcut, and removal guidance shortcut.
+- Add startup FUSE warning dialog with remediation options when FUSE is unavailable.
+
 # v1.3.7
 
 - Add persistent Local Library indexing with startup + scheduled rescans to track stored files across app restarts.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+# v1.3.7
+
+- Add persistent Local Library indexing with startup + scheduled rescans to track stored files across app restarts.
+- Improve update/reinstall behavior with automatic re-download fallback when local files are missing or outside the active download path.
+- Add `Download Only` and `Re-download` queue options with completed-item requeue support.
+- Prevent nested duplicate download folders by normalizing release paths during download/fallback flows.
+- Fix install pipeline to stop immediately on APK install failure (no OBB push after failed APK install).
+- Propagate real ADB install errors (e.g. `INSTALL_FAILED_*`) into queue state and show them as `Install Error` tooltips in list/dialog UI.
+- Add status-column icon toggles for filtering Installed / Stored Locally items, including excluded (red strike-through) state.
+- Improve sortable header indicators with Fluent sort-line icons for unsorted/asc/desc states.
+- Add stalled public-download watchdog handling to avoid queue hangs on zero-progress transfers.
+
 # v1.3.6
 
 - Fix download progress display for direct HTTP downloads by parsing rclone stats output.

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -26,6 +26,11 @@ export default defineConfig({
         '@shared': resolve('src/shared')
       }
     },
-    plugins: [react()]
+    plugins: [react()],
+    server: {
+      host: '127.0.0.1',
+      port: 5174,
+      strictPort: true
+    }
   }
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apprenticevr",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apprenticevr",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apprenticevr",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apprenticevr",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",
@@ -20,6 +20,7 @@
     "build:win:x64": "electron-vite build && electron-builder --win --x64",
     "build:win:ia32": "electron-vite build && electron-builder --win --ia32",
     "build:mac": "electron-vite build && electron-builder --mac",
+    "build:mac:unsigned": "CSC_IDENTITY_AUTO_DISCOVERY=false electron-vite build && electron-builder --mac",
     "build:mac:x64": "electron-vite build && electron-builder --mac --x64",
     "build:mac:arm64": "electron-vite build && electron-builder --mac --arm64",
     "build:mac:universal": "electron-vite build && electron-builder --mac --universal",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -161,8 +161,8 @@ function sendDependencyProgress(
 async function createWindow(): Promise<void> {
   // Create the browser window.
   mainWindow = new BrowserWindow({
-    width: 1200,
-    minWidth: 1200,
+    width: 1250,
+    minWidth: 1250,
     height: 900,
     show: false,
     autoHideMenuBar: true,
@@ -176,7 +176,7 @@ async function createWindow(): Promise<void> {
   })
 
   // Explicitly set minimum size to ensure constraint is enforced
-  mainWindow.setMinimumSize(1200, 900)
+  mainWindow.setMinimumSize(1250, 900)
 
   mainWindow.on('ready-to-show', async () => {
     if (mainWindow) {
@@ -722,6 +722,7 @@ app.whenReady().then(async () => {
     console.log(`[IPC] OBB folder copy requested for ${folderPath} on device ${deviceId}`)
     return await downloadService.copyObbFolder(folderPath, deviceId)
   })
+
 
   // Validate that all IPC channels have handlers registered
   const allHandled = typedIpcMain.validateAllHandlersRegistered()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,6 @@
 import { app, shell, BrowserWindow, protocol, dialog, ipcMain } from 'electron'
-import { join } from 'path'
+import { join, normalize, extname, sep } from 'path'
+import { createServer, Server } from 'http'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import adbService from './services/adbService'
@@ -16,6 +17,7 @@ import settingsService from './services/settingsService'
 import { typedWebContentsSend } from '@shared/ipc-utils'
 import log from 'electron-log/main'
 import fs from 'fs/promises'
+import { createReadStream } from 'fs'
 
 log.transports.file.resolvePathFn = () => {
   return logsService.getLogFilePath()
@@ -30,6 +32,110 @@ Object.assign(console, log.functions)
 app.commandLine.appendSwitch('gtk-version', '3')
 
 let mainWindow: BrowserWindow | null = null
+let rendererServer: { url: string; close: () => Promise<void> } | null = null
+
+const getMimeType = (filePath: string): string => {
+  const ext = extname(filePath).toLowerCase()
+  switch (ext) {
+    case '.html':
+      return 'text/html'
+    case '.js':
+      return 'text/javascript'
+    case '.css':
+      return 'text/css'
+    case '.json':
+      return 'application/json'
+    case '.svg':
+      return 'image/svg+xml'
+    case '.png':
+      return 'image/png'
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg'
+    case '.webp':
+      return 'image/webp'
+    case '.gif':
+      return 'image/gif'
+    case '.wasm':
+      return 'application/wasm'
+    default:
+      return 'application/octet-stream'
+  }
+}
+
+const startRendererServer = async (rootDir: string): Promise<{ url: string; close: () => Promise<void> }> => {
+  const normalizedRoot = normalize(rootDir)
+
+  return await new Promise((resolve, reject) => {
+    const server: Server = createServer(async (req, res) => {
+      try {
+        if (!req.url) {
+          res.statusCode = 400
+          res.end('Bad Request')
+          return
+        }
+
+        const requestUrl = new URL(req.url, 'http://127.0.0.1')
+        let pathname = decodeURIComponent(requestUrl.pathname)
+
+        if (pathname === '/') {
+          pathname = '/index.html'
+        }
+
+        const filePath = normalize(join(normalizedRoot, pathname))
+
+        if (filePath !== normalizedRoot && !filePath.startsWith(normalizedRoot + sep)) {
+          res.statusCode = 403
+          res.end('Forbidden')
+          return
+        }
+
+        const stat = await fs.stat(filePath)
+        if (stat.isDirectory()) {
+          res.statusCode = 404
+          res.end('Not Found')
+          return
+        }
+
+        res.setHeader('Content-Type', getMimeType(filePath))
+        res.setHeader('Cache-Control', 'no-cache')
+
+        const stream = createReadStream(filePath)
+        stream.on('error', (error) => {
+          console.error('[RendererServer] Stream error:', error)
+          if (!res.headersSent) {
+            res.statusCode = 500
+          }
+          res.end('Server Error')
+        })
+        stream.pipe(res)
+      } catch {
+        res.statusCode = 404
+        res.end('Not Found')
+      }
+    })
+
+    server.on('error', (error) => {
+      reject(error)
+    })
+
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to bind renderer server'))
+        return
+      }
+      const url = `http://127.0.0.1:${address.port}`
+      resolve({
+        url,
+        close: () =>
+          new Promise<void>((closeResolve) => {
+            server.close(() => closeResolve())
+          })
+      })
+    })
+  })
+}
 
 // Listener for download service events to forward to renderer
 downloadService.on('installation:success', (deviceId) => {
@@ -52,7 +158,7 @@ function sendDependencyProgress(
   }
 }
 
-function createWindow(): void {
+async function createWindow(): Promise<void> {
   // Create the browser window.
   mainWindow = new BrowserWindow({
     width: 1200,
@@ -172,7 +278,11 @@ function createWindow(): void {
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    if (!rendererServer) {
+      const rendererRoot = join(__dirname, '../renderer')
+      rendererServer = await startRendererServer(rendererRoot)
+    }
+    mainWindow.loadURL(rendererServer.url)
   }
 }
 
@@ -622,7 +732,7 @@ app.whenReady().then(async () => {
   }
 
   // Create window FIRST
-  createWindow()
+  await createWindow()
 
   app.on('activate', function () {
     // On macOS it's common to re-create a window in the app when the
@@ -644,6 +754,12 @@ app.on('window-all-closed', () => {
 // Clean up ADB tracking when app is quitting
 app.on('will-quit', () => {
   adbService.stopTrackingDevices()
+  if (rendererServer) {
+    rendererServer.close().catch((error) => {
+      console.warn('Failed to close renderer server:', error)
+    })
+    rendererServer = null
+  }
 })
 
 // In this file you can include the rest of your app's specific main process

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,7 @@ import logsService from './services/logsService'
 import mirrorService from './services/mirrorService'
 import wifiBookmarksService from './services/wifiBookmarksService'
 import localLibraryService from './services/localLibraryService'
+import fuseService from './services/fuseService'
 import { typedIpcMain } from '@shared/ipc-utils'
 import settingsService from './services/settingsService'
 import { typedWebContentsSend } from '@shared/ipc-utils'
@@ -34,6 +35,7 @@ app.commandLine.appendSwitch('gtk-version', '3')
 
 let mainWindow: BrowserWindow | null = null
 let rendererServer: { url: string; close: () => Promise<void> } | null = null
+let hasShownFuseMissingDialog = false
 
 const getMimeType = (filePath: string): string => {
   const ext = extname(filePath).toLowerCase()
@@ -165,6 +167,38 @@ function sendDependencyProgress(
   }
 }
 
+async function showFuseMissingDialogIfNeeded(): Promise<void> {
+  if (hasShownFuseMissingDialog) return
+  if (!mainWindow || mainWindow.isDestroyed()) return
+
+  try {
+    const fuseStatus = await fuseService.getStatus()
+    if (!fuseStatus.supported || fuseStatus.available) return
+
+    hasShownFuseMissingDialog = true
+    const installButton = 'Install FUSE'
+    const continueButton = 'Continue Without FUSE'
+
+    const result = await dialog.showMessageBox(mainWindow, {
+      type: 'warning',
+      title: 'FUSE Not Installed',
+      message: 'Mount-based downloads are unavailable because FUSE is not installed.',
+      detail:
+        'What this means:\n- With FUSE: mount-based downloads are available and generally more resilient.\n- Without FUSE: the app uses direct download fallback, which can be slower and more likely to stall on unstable links.\n\nHow to fix:\nClick "Install FUSE", complete installation, then restart Apprentice VR.',
+      buttons: [installButton, continueButton],
+      defaultId: 0,
+      cancelId: 1,
+      noLink: true
+    })
+
+    if (result.response === 0) {
+      await fuseService.openInstaller()
+    }
+  } catch (error) {
+    console.warn('[Main] Failed to show FUSE guidance dialog:', error)
+  }
+}
+
 async function createWindow(): Promise<void> {
   // Create the browser window.
   mainWindow = new BrowserWindow({
@@ -234,6 +268,8 @@ async function createWindow(): Promise<void> {
             await localLibraryService.initialize()
             console.log('Local Library Service initialized.')
             dependencyService.setDependencyServiceStatus('INITIALIZED')
+
+            await showFuseMissingDialogIfNeeded()
 
             // Initialize Update Service
             if (mainWindow) {
@@ -394,19 +430,15 @@ app.whenReady().then(async () => {
   typedIpcMain.handle('download:delete-files', (_event, releaseName) =>
     downloadService.deleteDownloadedFiles(releaseName)
   )
-  typedIpcMain.handle('download:install-from-completed', (_event, releaseName, deviceId) => {
+  typedIpcMain.handle(
+    'download:install-from-completed',
+    async (_event, releaseName, deviceId) => {
     console.log(
       `[IPC] Received request to install from completed: ${releaseName} on device ${deviceId}`
     )
-    // No return value needed, fire-and-forget, status updated via queue listener
-    downloadService.installFromCompleted(releaseName, deviceId).catch((err) => {
-      // Log error here as the renderer won't get a rejection for this invoke
-      console.error(
-        `[IPC Handler Error] installFromCompleted failed for ${releaseName} on ${deviceId}:`,
-        err
-      )
-    })
-  })
+      await downloadService.installFromCompleted(releaseName, deviceId)
+    }
+  )
   typedIpcMain.handle('local-library:get-index', async () => localLibraryService.getIndex())
   typedIpcMain.handle('local-library:rescan', async () => await localLibraryService.rescan())
 
@@ -540,6 +572,12 @@ app.whenReady().then(async () => {
   typedIpcMain.handle('settings:get-color-scheme', () => settingsService.getColorScheme())
   typedIpcMain.handle('settings:set-color-scheme', (_event, scheme) =>
     settingsService.setColorScheme(scheme)
+  )
+  typedIpcMain.handle('settings:get-fuse-status', async () => await fuseService.getStatus())
+  typedIpcMain.handle('settings:open-fuse-installer', async () => await fuseService.openInstaller())
+  typedIpcMain.handle(
+    'settings:open-fuse-removal-guide',
+    async () => await fuseService.openRemovalGuide()
   )
 
   // --- Logs Handlers ---

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,6 +12,7 @@ import updateService from './services/updateService'
 import logsService from './services/logsService'
 import mirrorService from './services/mirrorService'
 import wifiBookmarksService from './services/wifiBookmarksService'
+import localLibraryService from './services/localLibraryService'
 import { typedIpcMain } from '@shared/ipc-utils'
 import settingsService from './services/settingsService'
 import { typedWebContentsSend } from '@shared/ipc-utils'
@@ -147,6 +148,12 @@ downloadService.on('installation:success', (deviceId) => {
   }
 })
 
+localLibraryService.on('updated', (index) => {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    typedWebContentsSend.send(mainWindow, 'local-library:updated', index)
+  }
+})
+
 // Function to send dependency progress to renderer
 function sendDependencyProgress(
   status: DependencyStatus,
@@ -222,6 +229,10 @@ async function createWindow(): Promise<void> {
             // Initialize WiFi Bookmarks Service
             await wifiBookmarksService.initialize()
             console.log('WiFi Bookmarks Service initialized.')
+
+            // Initialize Local Library Service
+            await localLibraryService.initialize()
+            console.log('Local Library Service initialized.')
             dependencyService.setDependencyServiceStatus('INITIALIZED')
 
             // Initialize Update Service
@@ -377,7 +388,9 @@ app.whenReady().then(async () => {
 
   // --- Download Handlers ---
   typedIpcMain.handle('download:get-queue', () => downloadService.getQueue())
-  typedIpcMain.handle('download:add', (_event, game) => downloadService.addToQueue(game))
+  typedIpcMain.handle('download:add', (_event, game, options) =>
+    downloadService.addToQueue(game, options)
+  )
   typedIpcMain.handle('download:delete-files', (_event, releaseName) =>
     downloadService.deleteDownloadedFiles(releaseName)
   )
@@ -394,6 +407,8 @@ app.whenReady().then(async () => {
       )
     })
   })
+  typedIpcMain.handle('local-library:get-index', async () => localLibraryService.getIndex())
+  typedIpcMain.handle('local-library:rescan', async () => await localLibraryService.rescan())
 
   // --- Upload Handlers ---
   typedIpcMain.handle(
@@ -755,6 +770,9 @@ app.on('window-all-closed', () => {
 // Clean up ADB tracking when app is quitting
 app.on('will-quit', () => {
   adbService.stopTrackingDevices()
+  localLibraryService.shutdown().catch((error) => {
+    console.warn('Failed to shutdown LocalLibraryService:', error)
+  })
   if (rendererServer) {
     rendererServer.close().catch((error) => {
       console.warn('Failed to close renderer server:', error)

--- a/src/main/services/adbService.ts
+++ b/src/main/services/adbService.ts
@@ -28,10 +28,15 @@ class AdbService extends EventEmitter implements AdbAPI {
   private isTracking = false
   private status: ServiceStatus = 'NOT_INITIALIZED'
   private aaptPushed = false
+  private lastInstallError: string | null = null
 
   constructor() {
     super()
     this.client = null
+  }
+
+  public getLastInstallError(): string | null {
+    return this.lastInstallError
   }
 
   public async initialize(): Promise<ServiceStatus> {
@@ -483,6 +488,7 @@ class AdbService extends EventEmitter implements AdbAPI {
     console.log(
       `[ADB Service] Attempting to install ${apkPath} on ${serial}${options?.flags ? ` with flags: ${options.flags.join(' ')}` : ''}...`
     )
+    this.lastInstallError = null
     const deviceClient = this.client.getDevice(serial)
 
     if (options?.flags && options.flags.length > 0) {
@@ -554,11 +560,13 @@ class AdbService extends EventEmitter implements AdbAPI {
         }
 
         if (output?.includes('Success')) {
+          this.lastInstallError = null
           console.log(
             `[ADB Service] Successfully installed ${apkPath} with flags. Output: ${output}`
           )
           return true
         } else {
+          this.lastInstallError = (output && output.trim()) || 'Installation failed'
           console.error(
             `[ADB Service] Installation of ${apkPath} with flags failed or success not confirmed. Output: ${output || 'No output'}`
           )
@@ -579,6 +587,7 @@ class AdbService extends EventEmitter implements AdbAPI {
           return false
         }
       } catch (error) {
+        this.lastInstallError = error instanceof Error ? error.message : String(error)
         console.error(
           `[ADB Service] Error during flagged installation of ${apkPath} on device ${serial}:`,
           error
@@ -599,14 +608,17 @@ class AdbService extends EventEmitter implements AdbAPI {
       try {
         const success = await deviceClient.install(apkPath)
         if (success) {
+          this.lastInstallError = null
           console.log(`[ADB Service] Successfully installed ${apkPath} using adbkit.install.`)
         } else {
+          this.lastInstallError = 'Installation reported failure'
           console.error(
             `[ADB Service] Installation of ${apkPath} reported failure by adbkit.install.`
           )
         }
         return success
       } catch (error) {
+        this.lastInstallError = error instanceof Error ? error.message : String(error)
         console.error(
           `[ADB Service] Error installing package ${apkPath} on device ${serial} (adbkit.install):`,
           error

--- a/src/main/services/dependencyService.ts
+++ b/src/main/services/dependencyService.ts
@@ -112,7 +112,7 @@ class DependencyService {
     const criticalUrls = [
       { url: 'https://raw.githubusercontent.com', name: 'GitHub' },
       { url: 'https://vrpirates.wiki', name: 'VRP Wiki' },
-      { url: 'https://go.vrpyourself.online', name: 'VRP Mirror' }
+      { url: 'https://there-is-a.vrpmonkey.help', name: 'VRP Mirror' }
     ]
 
     const failedUrls: string[] = []

--- a/src/main/services/download/downloadProcessor.ts
+++ b/src/main/services/download/downloadProcessor.ts
@@ -28,7 +28,9 @@ export class DownloadProcessor {
   private queueManager: QueueManager
   private vrpConfig: VrpConfig | null = null
   private debouncedEmitUpdate: () => void
-  private static readonly PUBLIC_DOWNLOAD_STALL_TIMEOUT_MS = 120000
+  private static readonly PUBLIC_DOWNLOAD_STALL_NO_DATA_TIMEOUT_MS = 180000
+  private static readonly PUBLIC_DOWNLOAD_STALL_IDLE_AFTER_PROGRESS_TIMEOUT_MS = 420000
+  private static readonly PUBLIC_DOWNLOAD_STALL_POLL_INTERVAL_MS = 10000
 
   constructor(queueManager: QueueManager, debouncedEmitUpdate: () => void) {
     this.queueManager = queueManager
@@ -290,6 +292,7 @@ export class DownloadProcessor {
       .update(item.releaseName + '\n')
       .digest('hex')
     const source = `:http:/${gameNameHash}`
+    const downloadSpeedLimit = settingsService.getDownloadSpeedLimit()
 
     const rcloneArgs = [
       'copy',
@@ -298,11 +301,32 @@ export class DownloadProcessor {
       '--http-url',
       this.vrpConfig.baseUri,
       '--no-check-certificate',
+      '--retries',
+      '6',
+      '--retries-sleep',
+      '5s',
+      '--low-level-retries',
+      '20',
+      '--contimeout',
+      '20s',
+      '--timeout',
+      '3m',
+      '--transfers',
+      '2',
+      '--checkers',
+      '6',
       '--progress',
       '--stats',
       '1s',
       '--stats-one-line'
     ]
+    if (Number.isFinite(downloadSpeedLimit) && downloadSpeedLimit > 0) {
+      // rclone treats bare numeric bwlimit values as KiB/s.
+      rcloneArgs.push('--bwlimit', `${Math.floor(downloadSpeedLimit)}`)
+      console.log(
+        `[DownProc] Applying direct-download speed limit for ${item.releaseName}: ${Math.floor(downloadSpeedLimit)} KiB/s`
+      )
+    }
 
     const rcloneLogTail: string[] = []
     const maxLogLines = 50
@@ -319,7 +343,13 @@ export class DownloadProcessor {
     let lastTransferredBytes = 0
     let lastAdvanceAt = Date.now()
     let killedByStallWatchdog = false
+    let stallThresholdAtKillMs = 0
     let stallWatchdog: NodeJS.Timeout | null = null
+
+    const getCurrentStallThresholdMs = (): number =>
+      lastTransferredBytes > 0
+        ? DownloadProcessor.PUBLIC_DOWNLOAD_STALL_IDLE_AFTER_PROGRESS_TIMEOUT_MS
+        : DownloadProcessor.PUBLIC_DOWNLOAD_STALL_NO_DATA_TIMEOUT_MS
 
     const parseTransferredBytes = (line: string): number | null => {
       const transferMatch = line.match(
@@ -422,17 +452,18 @@ export class DownloadProcessor {
         if (!currentItem || currentItem.status !== 'Downloading') return
 
         const idleMs = Date.now() - lastAdvanceAt
-        if (
-          idleMs >= DownloadProcessor.PUBLIC_DOWNLOAD_STALL_TIMEOUT_MS &&
-          (lastProgress < 100 || lastTransferredBytes === 0)
-        ) {
+        const stallThresholdMs = getCurrentStallThresholdMs()
+        if (idleMs >= stallThresholdMs && lastProgress < 100) {
           killedByStallWatchdog = true
+          stallThresholdAtKillMs = stallThresholdMs
+          const phase =
+            lastTransferredBytes > 0 ? 'after transfer activity' : 'before first transferred byte'
           console.error(
-            `[DownProc] Detected stalled rclone download for ${item.releaseName} (no transfer progress for ${Math.round(idleMs / 1000)}s). Terminating process.`
+            `[DownProc] Detected stalled rclone download for ${item.releaseName} (${phase}; no transfer progress for ${Math.round(idleMs / 1000)}s). Terminating process.`
           )
           rcloneProcess.kill('SIGTERM')
         }
-      }, 10000)
+      }, DownloadProcessor.PUBLIC_DOWNLOAD_STALL_POLL_INTERVAL_MS)
 
       console.log(
         `[DownProc] rclone process started for ${item.releaseName} with PID: ${rcloneProcess.pid}`
@@ -486,8 +517,11 @@ export class DownloadProcessor {
 
       let errorMessage = 'Public endpoint download failed.'
       if (killedByStallWatchdog) {
+        const thresholdSeconds = Math.round(
+          (stallThresholdAtKillMs || getCurrentStallThresholdMs()) / 1000
+        )
         errorMessage = `Download stalled: no transfer progress for ${Math.round(
-          DownloadProcessor.PUBLIC_DOWNLOAD_STALL_TIMEOUT_MS / 1000
+          thresholdSeconds
         )}s`
       } else if (isExecaError(error)) {
         errorMessage = error.shortMessage || error.message

--- a/src/main/services/download/downloadProcessor.ts
+++ b/src/main/services/download/downloadProcessor.ts
@@ -1,4 +1,4 @@
-import { join } from 'path'
+import { basename, dirname, join } from 'path'
 import { promises as fs, createReadStream, createWriteStream, promises as fsPromises } from 'fs'
 import { execa, ExecaError } from 'execa'
 import crypto from 'crypto'
@@ -28,6 +28,7 @@ export class DownloadProcessor {
   private queueManager: QueueManager
   private vrpConfig: VrpConfig | null = null
   private debouncedEmitUpdate: () => void
+  private static readonly PUBLIC_DOWNLOAD_STALL_TIMEOUT_MS = 120000
 
   constructor(queueManager: QueueManager, debouncedEmitUpdate: () => void) {
     this.queueManager = queueManager
@@ -36,6 +37,28 @@ export class DownloadProcessor {
 
   public setVrpConfig(config: VrpConfig | null): void {
     this.vrpConfig = config
+  }
+
+  /**
+   * Resolve the item download directory while preventing repeated
+   * "<release>/<release>/..." path nesting across fallback/retry flows.
+   */
+  private resolveItemDownloadPath(item: DownloadItem): string {
+    let basePath = item.downloadPath
+
+    // Collapse duplicate trailing release-name segments if they exist.
+    while (
+      basename(basePath) === item.releaseName &&
+      basename(dirname(basePath)) === item.releaseName
+    ) {
+      basePath = dirname(basePath)
+    }
+
+    if (basename(basePath) === item.releaseName) {
+      return basePath
+    }
+
+    return join(basePath, item.releaseName)
   }
 
   // Add getter for vrpConfig
@@ -146,7 +169,7 @@ export class DownloadProcessor {
       return { success: false, startExtraction: false }
     }
 
-    const downloadPath = join(item.downloadPath, item.releaseName)
+    const downloadPath = this.resolveItemDownloadPath(item)
     this.queueManager.updateItem(item.releaseName, { downloadPath: downloadPath })
 
     try {
@@ -259,7 +282,7 @@ export class DownloadProcessor {
       return { success: false, startExtraction: false }
     }
 
-    const downloadPath = join(item.downloadPath, item.releaseName)
+    const downloadPath = this.resolveItemDownloadPath(item)
     this.queueManager.updateItem(item.releaseName, { downloadPath: downloadPath })
 
     const gameNameHash = crypto
@@ -293,6 +316,47 @@ export class DownloadProcessor {
     }
 
     let lastProgress = -1
+    let lastTransferredBytes = 0
+    let lastAdvanceAt = Date.now()
+    let killedByStallWatchdog = false
+    let stallWatchdog: NodeJS.Timeout | null = null
+
+    const parseTransferredBytes = (line: string): number | null => {
+      const transferMatch = line.match(
+        /([0-9]+(?:\.[0-9]+)?)\s*([KMGTPE]?i?B)\s*\/\s*([0-9]+(?:\.[0-9]+)?)\s*([KMGTPE]?i?B)/i
+      )
+      if (!transferMatch) return null
+
+      const value = Number(transferMatch[1])
+      const unit = transferMatch[2].toUpperCase()
+      if (Number.isNaN(value)) return null
+
+      const scale: Record<string, number> = {
+        B: 1,
+        KIB: 1024,
+        MIB: 1024 ** 2,
+        GIB: 1024 ** 3,
+        TIB: 1024 ** 4,
+        PIB: 1024 ** 5,
+        EIB: 1024 ** 6,
+        KB: 1000,
+        MB: 1000 ** 2,
+        GB: 1000 ** 3,
+        TB: 1000 ** 4,
+        PB: 1000 ** 5,
+        EB: 1000 ** 6
+      }
+
+      const multiplier = scale[unit]
+      if (!multiplier) return null
+
+      return Math.floor(value * multiplier)
+    }
+
+    const bumpActivity = (): void => {
+      lastAdvanceAt = Date.now()
+    }
+
     const handleRcloneOutput = (chunk: Buffer): void => {
       const text = chunk.toString().replace(/\r/g, '\n')
       const lines = text.split(/\n/)
@@ -301,12 +365,19 @@ export class DownloadProcessor {
           console.log(`[DownProc][rclone] ${line}`)
           pushLogLine(line)
 
+          const transferredBytes = parseTransferredBytes(line)
+          if (transferredBytes !== null && transferredBytes > lastTransferredBytes) {
+            lastTransferredBytes = transferredBytes
+            bumpActivity()
+          }
+
           const progressMatch =
             line.match(/Transferred:.*?(\d+)%/) || line.match(/,\s*(\d+)%\s*,/)
           if (progressMatch && progressMatch[1]) {
             const progress = Number(progressMatch[1])
             if (!Number.isNaN(progress) && progress !== lastProgress) {
               lastProgress = progress
+              bumpActivity()
 
               const speedMatch = line.match(/,\s*([0-9.]+\s*\w+\/s)(?:,|$)/)
               const etaMatch = line.match(/ETA\s+([0-9hms:]+|[-]+)\b/i)
@@ -345,11 +416,34 @@ export class DownloadProcessor {
         mountProcess: rcloneProcess
       })
 
+      stallWatchdog = setInterval(() => {
+        if (killedByStallWatchdog) return
+        const currentItem = this.queueManager.findItem(item.releaseName)
+        if (!currentItem || currentItem.status !== 'Downloading') return
+
+        const idleMs = Date.now() - lastAdvanceAt
+        if (
+          idleMs >= DownloadProcessor.PUBLIC_DOWNLOAD_STALL_TIMEOUT_MS &&
+          (lastProgress < 100 || lastTransferredBytes === 0)
+        ) {
+          killedByStallWatchdog = true
+          console.error(
+            `[DownProc] Detected stalled rclone download for ${item.releaseName} (no transfer progress for ${Math.round(idleMs / 1000)}s). Terminating process.`
+          )
+          rcloneProcess.kill('SIGTERM')
+        }
+      }, 10000)
+
       console.log(
         `[DownProc] rclone process started for ${item.releaseName} with PID: ${rcloneProcess.pid}`
       )
 
       await rcloneProcess
+
+      if (stallWatchdog) {
+        clearInterval(stallWatchdog)
+        stallWatchdog = null
+      }
 
       this.activeDownloads.delete(item.releaseName)
       this.queueManager.updateItem(item.releaseName, { pid: undefined })
@@ -375,18 +469,27 @@ export class DownloadProcessor {
         console.error(`[DownProc] rclone log tail:\n${rcloneLogTail.join('\n')}`)
       }
 
+      if (stallWatchdog) {
+        clearInterval(stallWatchdog)
+        stallWatchdog = null
+      }
+
       if (this.activeDownloads.has(item.releaseName)) {
         this.activeDownloads.delete(item.releaseName)
         this.queueManager.updateItem(item.releaseName, { pid: undefined })
       }
 
-      if (isExecaError(error) && error.exitCode === 143) {
+      if (isExecaError(error) && error.exitCode === 143 && !killedByStallWatchdog) {
         console.log(`[DownProc] rclone download cancelled for ${item.releaseName}`)
         return { success: false, startExtraction: false, finalState: currentItemState }
       }
 
       let errorMessage = 'Public endpoint download failed.'
-      if (isExecaError(error)) {
+      if (killedByStallWatchdog) {
+        errorMessage = `Download stalled: no transfer progress for ${Math.round(
+          DownloadProcessor.PUBLIC_DOWNLOAD_STALL_TIMEOUT_MS / 1000
+        )}s`
+      } else if (isExecaError(error)) {
         errorMessage = error.shortMessage || error.message
       } else if (error instanceof Error) {
         errorMessage = error.message
@@ -432,7 +535,7 @@ export class DownloadProcessor {
       return { success: false, startExtraction: false }
     }
 
-    const downloadPath = join(item.downloadPath, item.releaseName)
+    const downloadPath = this.resolveItemDownloadPath(item)
     this.queueManager.updateItem(item.releaseName, { downloadPath: downloadPath })
 
     // Create unique mount point for this download (sanitize name to avoid issues)

--- a/src/main/services/download/installationProcessor.ts
+++ b/src/main/services/download/installationProcessor.ts
@@ -166,8 +166,17 @@ export class InstallationProcessor {
                   // Ensure -r and -g are included for compatibility and permissions.
                   const combinedFlags = Array.from(new Set(['-r', '-g', ...installArgs]))
 
-                  await this.adbService.installPackage(deviceId, apkPath, { flags: combinedFlags })
-                  commandSuccess = true // Assuming installPackage throws on error
+                  const installSucceeded = await this.adbService.installPackage(deviceId, apkPath, {
+                    flags: combinedFlags
+                  })
+                  if (installSucceeded) {
+                    commandSuccess = true
+                  } else {
+                    const installError = this.adbService.getLastInstallError()
+                    errorMessage = installError
+                      ? `Install command failed for ${apkArg}: ${installError}`
+                      : `Install command failed for ${apkArg}`
+                  }
                   // if (output?.includes('Success')) {
                   //   commandSuccess = true
                   // } else {
@@ -307,7 +316,23 @@ export class InstallationProcessor {
         console.log(`[InstallProc Standard] Installing ${apkPath}...`)
         try {
           // Use the simplified installPackage, now with flags for reinstall and granting permissions
-          await this.adbService.installPackage(deviceId, apkPath, { flags: ['-r', '-g'] })
+          const installSucceeded = await this.adbService.installPackage(deviceId, apkPath, {
+            flags: ['-r', '-g']
+          })
+          if (!installSucceeded) {
+            const installError = this.adbService.getLastInstallError()
+            console.error(`[InstallProc Standard] Failed to install ${apk} (adb returned false)`)
+            this.updateItemStatus(
+              item.releaseName,
+              'InstallError',
+              100,
+              installError
+                ? `Failed to install ${apk}: ${installError}`
+                : `Failed to install ${apk}: device rejected install`,
+              100
+            )
+            return false
+          }
           console.log(`[InstallProc Standard] Successfully installed ${apk}`)
         } catch (installError: unknown) {
           const errorMsg =

--- a/src/main/services/downloadService.ts
+++ b/src/main/services/downloadService.ts
@@ -525,13 +525,61 @@ class DownloadService extends EventEmitter implements DownloadAPI {
     return Promise.resolve()
   }
 
-  public retryDownload(releaseName: string): Promise<void> {
+  public async retryDownload(releaseName: string): Promise<void> {
     const item = this.queueManager.findItem(releaseName)
     if (
       item &&
       (item.status === 'Cancelled' || item.status === 'Error' || item.status === 'InstallError')
     ) {
       console.log(`[Service] Retrying download: ${releaseName}`)
+
+      if (item.status === 'InstallError') {
+        const hasReusableLocalPayload =
+          !!item.downloadPath &&
+          existsSync(item.downloadPath) &&
+          (await this.hasInstallablePayload(item.downloadPath))
+
+        if (hasReusableLocalPayload) {
+          const resetToCompleted = this.queueManager.updateItem(releaseName, {
+            status: 'Completed',
+            error: undefined,
+            pid: undefined,
+            speed: undefined,
+            eta: undefined,
+            progress: 100
+          })
+
+          if (resetToCompleted) {
+            this.emitUpdate()
+          }
+
+          const targetDevice = this.getTargetDeviceForInstallation()
+          if (!targetDevice) {
+            console.warn(
+              `[Service Retry] ${releaseName} has local payload but no connected target device. Kept in Completed state.`
+            )
+            return Promise.resolve()
+          }
+
+          console.log(
+            `[Service Retry] Retrying installation from existing local payload for ${releaseName} on ${targetDevice}.`
+          )
+          try {
+            await this.installFromCompleted(releaseName, targetDevice)
+            return Promise.resolve()
+          } catch (error) {
+            console.warn(
+              `[Service Retry] Local install retry failed for ${releaseName}, falling back to re-download:`,
+              error
+            )
+            // Fall through to queue-based re-download retry path.
+          }
+        } else {
+          console.log(
+            `[Service Retry] No reusable local payload found for ${releaseName}. Falling back to re-download.`
+          )
+        }
+      }
 
       if (this.downloadProcessor.isDownloadActive(releaseName)) {
         console.warn(
@@ -635,7 +683,7 @@ class DownloadService extends EventEmitter implements DownloadAPI {
 
     if (!item) {
       console.error(`[Service installFromCompleted] Item not found: ${releaseName}`)
-      throw new Error(`Item not found: ${releaseName}`)
+      throw new Error('COMPLETED_ITEM_NOT_FOUND')
     }
 
     if (item.status !== 'Completed') {

--- a/src/main/services/downloadService.ts
+++ b/src/main/services/downloadService.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from 'electron'
 import { promises as fs, existsSync } from 'fs'
+import { resolve, sep } from 'path'
 import adbService from './adbService'
 import { EventEmitter } from 'events'
 import { debounce } from './download/utils'
@@ -7,9 +8,16 @@ import { QueueManager } from './download/queueManager'
 import { DownloadProcessor } from './download/downloadProcessor'
 import { ExtractionProcessor } from './download/extractionProcessor'
 import { InstallationProcessor } from './download/installationProcessor'
-import { DownloadAPI, GameInfo, DownloadItem, DownloadStatus } from '@shared/types'
+import {
+  DownloadAPI,
+  GameInfo,
+  DownloadItem,
+  DownloadStatus,
+  DownloadAddOptions
+} from '@shared/types'
 import settingsService from './settingsService'
 import { typedWebContentsSend } from '@shared/ipc-utils'
+import localLibraryService from './localLibraryService'
 
 interface VrpConfig {
   baseUri?: string
@@ -118,7 +126,7 @@ class DownloadService extends EventEmitter implements DownloadAPI {
     return Promise.resolve(this.queueManager.getQueue())
   }
 
-  public addToQueue(game: GameInfo): Promise<boolean> {
+  public addToQueue(game: GameInfo, options?: DownloadAddOptions): Promise<boolean> {
     if (!this.isInitialized) {
       console.error('DownloadService not initialized. Cannot add to queue.')
       return Promise.resolve(false)
@@ -132,8 +140,14 @@ class DownloadService extends EventEmitter implements DownloadAPI {
 
     if (existing) {
       if (existing.status === 'Completed') {
-        console.log(`Game ${game.releaseName} already downloaded.`)
-        return Promise.resolve(false)
+        if (!options?.forceRequeueCompleted) {
+          console.log(`Game ${game.releaseName} already downloaded.`)
+          return Promise.resolve(false)
+        }
+        console.log(
+          `Re-queue requested for completed item ${game.releaseName}; replacing existing queue entry.`
+        )
+        this.queueManager.removeItem(game.releaseName)
       } else if (existing.status !== 'Error' && existing.status !== 'Cancelled') {
         console.log(
           `Game ${game.releaseName} is already in the queue with status: ${existing.status}.`
@@ -154,7 +168,8 @@ class DownloadService extends EventEmitter implements DownloadAPI {
       addedDate: Date.now(),
       thumbnailPath: game.thumbnailPath,
       downloadPath: this.downloadsPath,
-      size: game.size
+      size: game.size,
+      skipInstall: options?.skipInstall === true
     }
     this.queueManager.addItem(newItem)
     console.log(`Added ${game.releaseName} to download queue.`)
@@ -285,6 +300,20 @@ class DownloadService extends EventEmitter implements DownloadAPI {
         return
       }
 
+      // Keep local library index in sync when content extraction has completed.
+      localLibraryService.rescan().catch((error) => {
+        console.warn('[Service ProcessQueue] Local library rescan failed after extraction:', error)
+      })
+
+      if (itemAfterExtraction.skipInstall) {
+        console.log(
+          `[Service ProcessQueue] Extraction successful for ${itemAfterExtraction.releaseName}. Auto-install skipped by request.`
+        )
+        this.isProcessing = false
+        this.processQueue()
+        return
+      }
+
       // Re-check connection state before installation (device might have disconnected during extraction)
       const finalTargetDeviceId = this.getTargetDeviceForInstallation()
       if (!finalTargetDeviceId) {
@@ -388,6 +417,28 @@ class DownloadService extends EventEmitter implements DownloadAPI {
     const mainWindow = BrowserWindow.getAllWindows()[0]
     if (mainWindow && !mainWindow.isDestroyed()) {
       typedWebContentsSend.send(mainWindow, 'download:queue-updated', this.queueManager.getQueue())
+    }
+  }
+
+  private isPathWithinRoot(pathToCheck: string, rootPath: string): boolean {
+    const normalizedPath = resolve(pathToCheck)
+    const normalizedRoot = resolve(rootPath)
+    return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}${sep}`)
+  }
+
+  private async hasInstallablePayload(downloadPath: string): Promise<boolean> {
+    try {
+      const entries = await fs.readdir(downloadPath)
+      return entries.some((entry) => {
+        const lower = entry.toLowerCase()
+        return lower.endsWith('.apk') || lower === 'install.txt'
+      })
+    } catch (error) {
+      console.warn(
+        `[Service installFromCompleted] Failed to inspect download path "${downloadPath}":`,
+        error
+      )
+      return false
     }
   }
 
@@ -560,6 +611,9 @@ class DownloadService extends EventEmitter implements DownloadAPI {
       console.log(`Deleted directory ${downloadPath}.`)
       const removed = this.queueManager.removeItem(releaseName)
       if (removed) this.emitUpdate()
+      localLibraryService.rescan().catch((error) => {
+        console.warn('[Service deleteDownloadedFiles] Local library rescan failed:', error)
+      })
       return true
     } catch (error: unknown) {
       console.error(`Error deleting ${downloadPath} for ${releaseName}:`, error)
@@ -589,6 +643,27 @@ class DownloadService extends EventEmitter implements DownloadAPI {
         `[Service installFromCompleted] Item ${releaseName} has status ${item.status}, not 'Completed'. Cannot start installation.`
       )
       throw new Error(`Item ${releaseName} is not in 'Completed' state.`)
+    }
+
+    if (!item.downloadPath || !existsSync(item.downloadPath)) {
+      console.warn(
+        `[Service installFromCompleted] Local files missing for ${releaseName}. Path: ${item.downloadPath}`
+      )
+      throw new Error('LOCAL_FILES_MISSING')
+    }
+
+    if (!this.isPathWithinRoot(item.downloadPath, this.downloadsPath)) {
+      console.warn(
+        `[Service installFromCompleted] Blocking install for ${releaseName}; path ${item.downloadPath} is outside active download root ${this.downloadsPath}.`
+      )
+      throw new Error('LOCAL_PATH_OUTSIDE_ACTIVE_DOWNLOAD_ROOT')
+    }
+
+    if (!(await this.hasInstallablePayload(item.downloadPath))) {
+      console.warn(
+        `[Service installFromCompleted] Local files missing install payload for ${releaseName} in ${item.downloadPath}.`
+      )
+      throw new Error('LOCAL_FILES_MISSING')
     }
 
     if (this.isProcessing) {

--- a/src/main/services/fuseService.ts
+++ b/src/main/services/fuseService.ts
@@ -1,0 +1,139 @@
+import { shell } from 'electron'
+import { existsSync } from 'fs'
+import { execa } from 'execa'
+import { FuseStatus } from '@shared/types'
+
+class FuseService {
+  private getInstallerUrl(): string | null {
+    if (process.platform === 'darwin') return 'https://macfuse.github.io/'
+    if (process.platform === 'linux') return 'https://github.com/libfuse/libfuse'
+    return null
+  }
+
+  private async isMacFuseInstalled(): Promise<{ available: boolean; detectedBy?: string }> {
+    const macFusePaths = [
+      '/Library/Filesystems/macfuse.fs',
+      '/Library/Filesystems/macfuse.fs/Contents/Resources/mount_macfuse',
+      '/opt/homebrew/bin/mount_macfuse',
+      '/usr/local/bin/mount_macfuse'
+    ]
+
+    for (const path of macFusePaths) {
+      if (existsSync(path)) {
+        return { available: true, detectedBy: path }
+      }
+    }
+
+    try {
+      const result = await execa('pkgutil', ['--pkgs'], {
+        reject: false,
+        timeout: 5000
+      })
+      if (
+        result.stdout
+          .split('\n')
+          .some((line) => line.toLowerCase().includes('macfuse') || line.includes('io.macfuse'))
+      ) {
+        return { available: true, detectedBy: 'pkgutil' }
+      }
+    } catch (error) {
+      console.warn('[FuseService] pkgutil detection failed:', error)
+    }
+
+    return { available: false }
+  }
+
+  private async isLinuxFuseInstalled(): Promise<{ available: boolean; detectedBy?: string }> {
+    if (existsSync('/dev/fuse')) {
+      return { available: true, detectedBy: '/dev/fuse' }
+    }
+
+    try {
+      const fusermount3 = await execa('which', ['fusermount3'], { reject: false, timeout: 3000 })
+      if (fusermount3.exitCode === 0 && fusermount3.stdout) {
+        return { available: true, detectedBy: fusermount3.stdout.trim() }
+      }
+
+      const fusermount = await execa('which', ['fusermount'], { reject: false, timeout: 3000 })
+      if (fusermount.exitCode === 0 && fusermount.stdout) {
+        return { available: true, detectedBy: fusermount.stdout.trim() }
+      }
+    } catch (error) {
+      console.warn('[FuseService] fusermount detection failed:', error)
+    }
+
+    return { available: false }
+  }
+
+  public async getStatus(): Promise<FuseStatus> {
+    if (process.platform === 'darwin') {
+      const detection = await this.isMacFuseInstalled()
+      return {
+        supported: true,
+        available: detection.available,
+        installable: true,
+        platform: process.platform,
+        message: detection.available
+          ? 'FUSE is available for mount-based downloads.'
+          : 'FUSE is not installed. Install macFUSE to enable mount-based downloads.',
+        detectedBy: detection.detectedBy
+      }
+    }
+
+    if (process.platform === 'linux') {
+      const detection = await this.isLinuxFuseInstalled()
+      return {
+        supported: true,
+        available: detection.available,
+        installable: true,
+        platform: process.platform,
+        message: detection.available
+          ? 'FUSE is available for mount-based downloads.'
+          : 'FUSE is not available. Install FUSE (libfuse) for mount-based downloads.',
+        detectedBy: detection.detectedBy
+      }
+    }
+
+    return {
+      supported: false,
+      available: false,
+      installable: false,
+      platform: process.platform,
+      message: 'FUSE mount support is not used on this platform.'
+    }
+  }
+
+  public async openInstaller(): Promise<boolean> {
+    const installerUrl = this.getInstallerUrl()
+    if (!installerUrl) return false
+    await shell.openExternal(installerUrl)
+    return true
+  }
+
+  public async openRemovalGuide(): Promise<boolean> {
+    if (process.platform === 'darwin') {
+      const uninstallAppCandidates = [
+        '/Library/Filesystems/macfuse.fs/Contents/Resources/uninstall-macfuse.app',
+        '/Library/Filesystems/macfuse.fs/Contents/Resources/Uninstall macFUSE.app'
+      ]
+
+      for (const uninstallAppPath of uninstallAppCandidates) {
+        if (!existsSync(uninstallAppPath)) continue
+        const openPathResult = await shell.openPath(uninstallAppPath)
+        if (!openPathResult) return true
+      }
+
+      await shell.openExternal('https://macfuse.github.io/')
+      return true
+    }
+
+    if (process.platform === 'linux') {
+      await shell.openExternal('https://github.com/libfuse/libfuse')
+      return true
+    }
+
+    return false
+  }
+}
+
+export default new FuseService()

--- a/src/main/services/localLibraryService.ts
+++ b/src/main/services/localLibraryService.ts
@@ -1,0 +1,274 @@
+import { app } from 'electron'
+import { EventEmitter } from 'events'
+import { basename, join } from 'path'
+import { Dirent, existsSync, promises as fs } from 'fs'
+import settingsService from './settingsService'
+import { LocalLibraryEntry, LocalLibraryIndex } from '@shared/types'
+
+const MAX_SCAN_DEPTH = 4
+const POLL_INTERVAL_MS = 30000
+
+class LocalLibraryService extends EventEmitter {
+  private readonly indexPath: string
+  private index: LocalLibraryIndex
+  private initialized = false
+  private scanRootPath: string
+  private scanTimeout: NodeJS.Timeout | null = null
+  private pollTimer: NodeJS.Timeout | null = null
+  private scanInProgress = false
+  private pendingScan = false
+
+  constructor() {
+    super()
+    this.indexPath = join(app.getPath('userData'), 'local-library-index.json')
+    this.scanRootPath = settingsService.getDownloadPath()
+    this.index = {
+      rootPath: this.scanRootPath,
+      generatedAt: Date.now(),
+      entries: []
+    }
+
+    settingsService.on('download-path-changed', (path: string) => {
+      this.scanRootPath = path
+      this.scheduleRescan(250)
+    })
+  }
+
+  public async initialize(): Promise<void> {
+    if (this.initialized) return
+
+    await this.loadIndexFromDisk()
+    this.scanRootPath = settingsService.getDownloadPath()
+
+    // Ensure root path is always aligned with current setting.
+    if (this.index.rootPath !== this.scanRootPath) {
+      this.index = {
+        rootPath: this.scanRootPath,
+        generatedAt: Date.now(),
+        entries: []
+      }
+      await this.saveIndexToDisk()
+    }
+
+    await this.rescan()
+
+    this.pollTimer = setInterval(() => {
+      this.scheduleRescan(0)
+    }, POLL_INTERVAL_MS)
+
+    this.initialized = true
+    console.log('[LocalLibrary] Service initialized.')
+  }
+
+  public async shutdown(): Promise<void> {
+    if (this.scanTimeout) {
+      clearTimeout(this.scanTimeout)
+      this.scanTimeout = null
+    }
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer)
+      this.pollTimer = null
+    }
+    this.initialized = false
+  }
+
+  public getIndex(): LocalLibraryIndex {
+    return this.index
+  }
+
+  public async rescan(): Promise<LocalLibraryIndex> {
+    if (this.scanInProgress) {
+      this.pendingScan = true
+      return this.index
+    }
+
+    this.scanInProgress = true
+
+    try {
+      const nextIndex = await this.buildIndex(this.scanRootPath)
+      const changed = this.isIndexChanged(this.index, nextIndex)
+
+      this.index = nextIndex
+
+      if (changed) {
+        await this.saveIndexToDisk()
+        this.emit('updated', this.index)
+        console.log(
+          `[LocalLibrary] Index updated. ${this.index.entries.length} local entry(ies) at ${this.index.rootPath}`
+        )
+      }
+
+      return this.index
+    } finally {
+      this.scanInProgress = false
+      if (this.pendingScan) {
+        this.pendingScan = false
+        this.scheduleRescan(100)
+      }
+    }
+  }
+
+  private scheduleRescan(delayMs: number): void {
+    if (this.scanTimeout) {
+      clearTimeout(this.scanTimeout)
+    }
+    this.scanTimeout = setTimeout(() => {
+      this.scanTimeout = null
+      this.rescan().catch((error) => {
+        console.error('[LocalLibrary] Scheduled rescan failed:', error)
+      })
+    }, delayMs)
+  }
+
+  private async loadIndexFromDisk(): Promise<void> {
+    try {
+      if (!existsSync(this.indexPath)) return
+      const content = await fs.readFile(this.indexPath, 'utf-8')
+      const parsed = JSON.parse(content) as LocalLibraryIndex
+      if (!parsed || !Array.isArray(parsed.entries) || typeof parsed.rootPath !== 'string') return
+      this.index = parsed
+    } catch (error) {
+      console.warn('[LocalLibrary] Failed to load index from disk:', error)
+    }
+  }
+
+  private async saveIndexToDisk(): Promise<void> {
+    try {
+      await fs.writeFile(this.indexPath, JSON.stringify(this.index, null, 2), 'utf-8')
+    } catch (error) {
+      console.warn('[LocalLibrary] Failed to save index to disk:', error)
+    }
+  }
+
+  private isIndexChanged(previous: LocalLibraryIndex, next: LocalLibraryIndex): boolean {
+    if (previous.rootPath !== next.rootPath) return true
+
+    const normalize = (index: LocalLibraryIndex): string =>
+      JSON.stringify({
+        rootPath: index.rootPath,
+        entries: index.entries.map((entry) => ({
+          id: entry.id,
+          releaseName: entry.releaseName,
+          path: entry.path,
+          source: entry.source,
+          apkCount: entry.apkCount,
+          hasInstallScript: entry.hasInstallScript,
+          packageNames: [...entry.packageNames].sort()
+        }))
+      })
+
+    return normalize(previous) !== normalize(next)
+  }
+
+  private async buildIndex(rootPath: string): Promise<LocalLibraryIndex> {
+    const generatedAt = Date.now()
+    const entries: LocalLibraryEntry[] = []
+
+    if (!rootPath || !existsSync(rootPath)) {
+      return { rootPath, generatedAt, entries }
+    }
+
+    let topLevelEntries: Dirent[] = []
+    try {
+      topLevelEntries = await fs.readdir(rootPath, { withFileTypes: true })
+    } catch (error) {
+      console.warn(`[LocalLibrary] Failed to read root path "${rootPath}":`, error)
+      return { rootPath, generatedAt, entries }
+    }
+
+    for (const topEntry of topLevelEntries) {
+      const fullPath = join(rootPath, topEntry.name)
+
+      if (topEntry.isFile() && topEntry.name.toLowerCase().endsWith('.apk')) {
+        const packageName = this.parsePackageNameFromApk(topEntry.name)
+        entries.push({
+          id: fullPath,
+          releaseName: basename(topEntry.name, '.apk'),
+          path: fullPath,
+          source: 'apk-file',
+          apkCount: 1,
+          hasInstallScript: false,
+          packageNames: packageName ? [packageName] : [],
+          lastSeen: generatedAt
+        })
+        continue
+      }
+
+      if (!topEntry.isDirectory()) continue
+
+      const folderScan = await this.scanDirectoryForInstallables(fullPath, 0)
+      if (folderScan.apkFiles.length === 0 && !folderScan.hasInstallScript) continue
+
+      const packageNames = Array.from(
+        new Set(
+          folderScan.apkFiles
+            .map((apkPath) => this.parsePackageNameFromApk(apkPath))
+            .filter((name): name is string => Boolean(name))
+        )
+      ).sort()
+
+      entries.push({
+        id: fullPath,
+        releaseName: topEntry.name,
+        path: fullPath,
+        source: 'folder',
+        apkCount: folderScan.apkFiles.length,
+        hasInstallScript: folderScan.hasInstallScript,
+        packageNames,
+        lastSeen: generatedAt
+      })
+    }
+
+    entries.sort((a, b) => a.releaseName.localeCompare(b.releaseName))
+    return { rootPath, generatedAt, entries }
+  }
+
+  private async scanDirectoryForInstallables(
+    dirPath: string,
+    depth: number
+  ): Promise<{ apkFiles: string[]; hasInstallScript: boolean }> {
+    const apkFiles: string[] = []
+    let hasInstallScript = false
+
+    let dirEntries: Dirent[] = []
+    try {
+      dirEntries = await fs.readdir(dirPath, { withFileTypes: true })
+    } catch {
+      return { apkFiles, hasInstallScript }
+    }
+
+    for (const entry of dirEntries) {
+      const entryPath = join(dirPath, entry.name)
+      const lowerName = entry.name.toLowerCase()
+
+      if (entry.isFile()) {
+        if (lowerName.endsWith('.apk')) apkFiles.push(entryPath)
+        if (lowerName === 'install.txt') hasInstallScript = true
+        continue
+      }
+
+      if (entry.isDirectory() && depth < MAX_SCAN_DEPTH) {
+        const nested = await this.scanDirectoryForInstallables(entryPath, depth + 1)
+        if (nested.apkFiles.length > 0) apkFiles.push(...nested.apkFiles)
+        if (nested.hasInstallScript) hasInstallScript = true
+      }
+    }
+
+    return { apkFiles, hasInstallScript }
+  }
+
+  private parsePackageNameFromApk(apkPathOrFileName: string): string | null {
+    const fileName = basename(apkPathOrFileName)
+    if (!fileName.toLowerCase().endsWith('.apk')) return null
+
+    const baseName = basename(fileName, '.apk')
+    // Typical Android package format, tolerant of uppercase segments seen in some releases.
+    if (!/^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+$/.test(baseName)) {
+      return null
+    }
+
+    return baseName
+  }
+}
+
+export default new LocalLibraryService()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,7 +20,10 @@ import {
   LogsAPIRenderer,
   MirrorAPIRenderer,
   Mirror,
-  WiFiBookmark
+  WiFiBookmark,
+  LocalLibraryAPIRenderer,
+  LocalLibraryIndex,
+  DownloadAddOptions
 } from '@shared/types'
 import { typedIpcRenderer } from '@shared/ipc-utils'
 
@@ -103,7 +106,8 @@ const api = {
   // Download Queue APIs
   downloads: {
     getQueue: (): Promise<DownloadItem[]> => typedIpcRenderer.invoke('download:get-queue'),
-    addToQueue: (game: GameInfo): Promise<boolean> => typedIpcRenderer.invoke('download:add', game),
+    addToQueue: (game: GameInfo, options?: DownloadAddOptions): Promise<boolean> =>
+      typedIpcRenderer.invoke('download:add', game, options),
     removeFromQueue: (releaseName: string): Promise<void> =>
       typedIpcRenderer.invoke('download:remove', releaseName),
     cancelUserRequest: (releaseName: string): void =>
@@ -132,6 +136,15 @@ const api = {
     setAppConnectionState: (selectedDevice: string | null, isConnected: boolean): void =>
       ipcRenderer.send('download:set-app-connection-state', selectedDevice, isConnected)
   } satisfies DownloadAPIRenderer,
+  localLibrary: {
+    getIndex: (): Promise<LocalLibraryIndex> => typedIpcRenderer.invoke('local-library:get-index'),
+    rescan: (): Promise<LocalLibraryIndex> => typedIpcRenderer.invoke('local-library:rescan'),
+    onUpdated: (callback: (index: LocalLibraryIndex) => void): (() => void) => {
+      const listener = (_: IpcRendererEvent, index: LocalLibraryIndex): void => callback(index)
+      typedIpcRenderer.on('local-library:updated', listener)
+      return () => typedIpcRenderer.removeListener('local-library:updated', listener)
+    }
+  } satisfies LocalLibraryAPIRenderer,
   // Upload APIs
   uploads: {
     prepareUpload: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -23,7 +23,8 @@ import {
   WiFiBookmark,
   LocalLibraryAPIRenderer,
   LocalLibraryIndex,
-  DownloadAddOptions
+  DownloadAddOptions,
+  FuseStatus
 } from '@shared/types'
 import { typedIpcRenderer } from '@shared/ipc-utils'
 
@@ -215,7 +216,12 @@ const api = {
     getColorScheme: (): Promise<'light' | 'dark'> =>
       typedIpcRenderer.invoke('settings:get-color-scheme'),
     setColorScheme: (scheme: 'light' | 'dark'): Promise<void> =>
-      typedIpcRenderer.invoke('settings:set-color-scheme', scheme)
+      typedIpcRenderer.invoke('settings:set-color-scheme', scheme),
+    getFuseStatus: (): Promise<FuseStatus> => typedIpcRenderer.invoke('settings:get-fuse-status'),
+    openFuseInstaller: (): Promise<boolean> =>
+      typedIpcRenderer.invoke('settings:open-fuse-installer'),
+    openFuseRemovalGuide: (): Promise<boolean> =>
+      typedIpcRenderer.invoke('settings:open-fuse-removal-guide')
   } satisfies SettingsAPIRenderer,
   // Logs APIs
   logs: {

--- a/src/renderer/src/assets/games-view.css
+++ b/src/renderer/src/assets/games-view.css
@@ -41,6 +41,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
   margin-bottom: 8px;
   padding-bottom: 8px;
   border-bottom: 1px solid #e0e0e0;
@@ -51,11 +52,17 @@
   display: flex;
   align-items: center;
   gap: 16px;
+  flex-wrap: nowrap;
+}
+
+.games-toolbar-left button {
+  white-space: nowrap;
 }
 
 .last-synced {
   color: var(--colorNeutralForeground2);
   font-size: 0.9em;
+  white-space: nowrap;
 }
 
 .game-count {
@@ -270,15 +277,20 @@
   display: flex;
   gap: 8px;
   margin-left: 16px;
+  flex-wrap: nowrap;
 }
 
 .filter-buttons button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   padding: 4px 10px;
   font-size: 0.85em;
   background-color: #f8f9fa;
   border: 1px solid #dadce0;
   border-radius: 12px; /* More rounded */
   cursor: pointer;
+  white-space: nowrap;
   transition:
     background-color 0.2s,
     border-color 0.2s,

--- a/src/renderer/src/assets/games-view.css
+++ b/src/renderer/src/assets/games-view.css
@@ -309,6 +309,42 @@
   font-weight: 500;
 }
 
+.status-header-filters {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.status-filter-toggle {
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.status-filter-icon-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+}
+
+.status-filter-toggle.excluded .status-filter-icon-wrap::after {
+  content: '';
+  position: absolute;
+  width: 21px;
+  border-top: 2px solid #ff4d4f;
+  transform: rotate(-28deg);
+}
+
 /* Add Row Background Styles */
 .row-installed .game-name-main {
   color: var(--colorBrandForeground1); /* Lighter green, slightly transparent */

--- a/src/renderer/src/assets/images/youtube-logo.svg
+++ b/src/renderer/src/assets/images/youtube-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 180" role="img" aria-label="YouTube logo">
+  <rect x="0" y="0" width="256" height="180" fill="none"/>
+  <g>
+    <rect x="10" y="30" width="236" height="120" rx="24" ry="24" fill="#FF0000"/>
+    <polygon points="110,70 110,110 150,90" fill="#FFFFFF"/>
+  </g>
+</svg>

--- a/src/renderer/src/components/GameDetailsDialog.tsx
+++ b/src/renderer/src/components/GameDetailsDialog.tsx
@@ -33,6 +33,7 @@ import {
   BroomRegular as UninstallIcon
 } from '@fluentui/react-icons'
 import placeholderImage from '../assets/images/game-placeholder.png'
+import youtubeLogo from '../assets/images/youtube-logo.svg'
 import YouTube from 'react-youtube'
 import { useGames } from '@renderer/hooks/useGames'
 
@@ -126,6 +127,43 @@ const useStyles = makeStyles({
     width: '100%',
     paddingTop: '56.25%', // 16:9 aspect ratio
     marginTop: tokens.spacingVerticalM
+  },
+  youtubeFallback: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    display: 'grid',
+    placeItems: 'center',
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderRadius: tokens.borderRadiusMedium,
+    overflow: 'hidden',
+    textAlign: 'center'
+  },
+  youtubeFallbackContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: tokens.spacingVerticalS,
+    padding: tokens.spacingVerticalM
+  },
+  youtubeFallbackThumb: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    position: 'absolute',
+    inset: 0,
+    filter: 'brightness(0.45)'
+  },
+  youtubeFallbackLogo: {
+    width: '120px',
+    height: 'auto',
+    marginBottom: tokens.spacingVerticalS
+  },
+  youtubeFallbackOverlay: {
+    position: 'relative',
+    zIndex: 1
   },
   youtubePlayer: {
     position: 'absolute',
@@ -552,17 +590,36 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
                 {loadingVideo ? (
                   <Spinner size="tiny" label="Searching for trailer..." />
                 ) : videoError && videoId ? (
-                  <Text>
-                    Trailer unavailable in-app.{' '}
-                    <a
-                      href={`https://www.youtube.com/watch?v=${videoId}`}
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Open on YouTube
-                    </a>
-                    .
-                  </Text>
+                  <div className={styles.youtubeContainer}>
+                    <div className={styles.youtubeFallback}>
+                      <img
+                        className={styles.youtubeFallbackThumb}
+                        src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
+                        alt="Trailer thumbnail"
+                      />
+                      <div className={styles.youtubeFallbackOverlay}>
+                        <div className={styles.youtubeFallbackContent}>
+                          <img
+                            className={styles.youtubeFallbackLogo}
+                            src={youtubeLogo}
+                            alt="YouTube"
+                          />
+                          <Text weight="semibold">Trailer can’t play in-app</Text>
+                          <Text size={200} style={{ color: tokens.colorNeutralForeground2 }}>
+                            Some videos block embeds. Open it on YouTube instead.
+                          </Text>
+                          <Button
+                            appearance="primary"
+                            onClick={() =>
+                              window.open(`https://www.youtube.com/watch?v=${videoId}`, '_blank')
+                            }
+                          >
+                            Open on YouTube
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 ) : videoId ? (
                   <div className={styles.youtubeContainer}>
                     <YouTube

--- a/src/renderer/src/components/GameDetailsDialog.tsx
+++ b/src/renderer/src/components/GameDetailsDialog.tsx
@@ -380,6 +380,14 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
             >
               Update
             </Button>
+            <Button
+              appearance="secondary"
+              icon={<DownloadIcon />}
+              onClick={() => onDownloadOnly(currentGame)}
+              disabled={isBusy}
+            >
+              Download Only
+            </Button>
             {!isStoredLocally && (
               <Button
                 appearance="secondary"
@@ -410,6 +418,14 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
               disabled={!isConnected || isBusy}
             >
               Reinstall
+            </Button>
+            <Button
+              appearance="secondary"
+              icon={<DownloadIcon />}
+              onClick={() => onDownloadOnly(currentGame)}
+              disabled={isBusy}
+            >
+              Download Only
             </Button>
             {!isStoredLocally && (
               <Button

--- a/src/renderer/src/components/GameDetailsDialog.tsx
+++ b/src/renderer/src/components/GameDetailsDialog.tsx
@@ -15,7 +15,8 @@ import {
   Badge,
   Divider,
   Spinner,
-  ProgressBar
+  ProgressBar,
+  Tooltip
 } from '@fluentui/react-components'
 import {
   ArrowClockwiseRegular,
@@ -188,8 +189,11 @@ interface GameDetailsDialogProps {
   game: GameInfo | null
   open: boolean
   onClose: () => void
-  downloadStatusMap: Map<string, { status: string; progress: number }>
+  downloadStatusMap: Map<string, { status: string; progress: number; error?: string }>
+  isStoredLocally: boolean
   onInstall: (game: GameInfo) => void
+  onDownloadOnly: (game: GameInfo) => void
+  onRedownload: (game: GameInfo) => void
   onUninstall: (game: GameInfo) => Promise<void>
   onReinstall: (game: GameInfo) => Promise<void>
   onUpdate: (game: GameInfo) => Promise<void>
@@ -207,7 +211,10 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
   open,
   onClose,
   downloadStatusMap,
+  isStoredLocally,
   onInstall,
+  onDownloadOnly,
+  onRedownload,
   onUninstall,
   onReinstall,
   onUpdate,
@@ -226,6 +233,9 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
   const [videoId, setVideoId] = useState<string | null>(null)
   const [loadingVideo, setLoadingVideo] = useState<boolean>(false)
   const [videoError, setVideoError] = useState<boolean>(false)
+  const statusInfo = game?.releaseName ? downloadStatusMap.get(game.releaseName) : undefined
+  const currentStatus = statusInfo?.status
+  const installErrorMessage = statusInfo?.error
 
   // Fetch note when dialog opens or game changes
   useEffect(() => {
@@ -306,7 +316,7 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
   const renderActionButtons = (currentGame: GameInfo): React.ReactNode => {
     const status = downloadStatusMap.get(currentGame.releaseName || '')?.status
     const canCancel = status === 'Downloading' || status === 'Extracting' || status === 'Queued'
-    const isDownloaded = status === 'Completed'
+    const isDownloaded = isStoredLocally
     const isInstalled = currentGame.isInstalled
     const hasUpdate = currentGame.hasUpdate
     const isInstallError = status === 'InstallError'
@@ -370,6 +380,16 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
             >
               Update
             </Button>
+            {!isStoredLocally && (
+              <Button
+                appearance="secondary"
+                icon={<DownloadIcon />}
+                onClick={() => onRedownload(currentGame)}
+                disabled={isBusy}
+              >
+                Re-download
+              </Button>
+            )}
             <Button
               appearance="danger"
               icon={<UninstallIcon />}
@@ -391,6 +411,16 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
             >
               Reinstall
             </Button>
+            {!isStoredLocally && (
+              <Button
+                appearance="secondary"
+                icon={<DownloadIcon />}
+                onClick={() => onRedownload(currentGame)}
+                disabled={isBusy}
+              >
+                Re-download
+              </Button>
+            )}
             <Button
               appearance="danger"
               icon={<UninstallIcon />}
@@ -428,14 +458,26 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
     }
 
     return (
-      <Button
-        appearance="primary"
-        icon={<DownloadIcon />}
-        onClick={() => onInstall(currentGame)}
-        disabled={isBusy}
-      >
-        {isConnected ? 'Install' : 'Download'}
-      </Button>
+      <>
+        <Button
+          appearance="primary"
+          icon={<DownloadIcon />}
+          onClick={() => onInstall(currentGame)}
+          disabled={isBusy}
+        >
+          {isConnected ? 'Install' : 'Download'}
+        </Button>
+        {isConnected && (
+          <Button
+            appearance="secondary"
+            icon={<DownloadIcon />}
+            onClick={() => onDownloadOnly(currentGame)}
+            disabled={isBusy}
+          >
+            Download Only
+          </Button>
+        )}
+      </>
     )
   }
 
@@ -501,27 +543,36 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
                     </Text>
                     <div className={styles.badgesAndInfoContainer}>
                       <div className={styles.badgeGroup}>
-                        <Badge
-                          shape="rounded"
-                          color={(() => {
-                            const status = downloadStatusMap.get(game.releaseName || '')?.status
-                            if (game.isInstalled) return 'success'
-                            if (status === 'Completed') return 'brand'
-                            if (status === 'InstallError') return 'danger'
-                            if (status === 'Installing') return 'brand'
-                            return 'informative'
-                          })()}
-                          appearance="filled"
-                        >
-                          {(() => {
-                            const status = downloadStatusMap.get(game.releaseName || '')?.status
-                            if (game.isInstalled) return 'Installed'
-                            if (status === 'Completed') return 'Downloaded'
-                            if (status === 'InstallError') return 'Install Error'
-                            if (status === 'Installing') return 'Installing'
-                            return 'Not Installed'
-                          })()}
-                        </Badge>
+                        {currentStatus === 'InstallError' && !game.isInstalled ? (
+                          <Tooltip
+                            content={installErrorMessage || 'Installation failed. Check logs for details.'}
+                            relationship="label"
+                          >
+                            <span>
+                              <Badge shape="rounded" color="danger" appearance="filled">
+                                Install Error
+                              </Badge>
+                            </span>
+                          </Tooltip>
+                        ) : (
+                          <Badge
+                            shape="rounded"
+                            color={(() => {
+                              if (game.isInstalled) return 'success'
+                              if (currentStatus === 'Completed') return 'brand'
+                              if (currentStatus === 'Installing') return 'brand'
+                              return 'informative'
+                            })()}
+                            appearance="filled"
+                          >
+                            {(() => {
+                              if (game.isInstalled) return 'Installed'
+                              if (currentStatus === 'Completed') return 'Downloaded'
+                              if (currentStatus === 'Installing') return 'Installing'
+                              return 'Not Installed'
+                            })()}
+                          </Badge>
+                        )}
                         {game.hasUpdate && (
                           <Badge shape="rounded" color="brand" appearance="filled">
                             Update Available

--- a/src/renderer/src/components/GamesView.tsx
+++ b/src/renderer/src/components/GamesView.tsx
@@ -937,6 +937,8 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
   const shouldFallbackToRedownload = (error: unknown): boolean => {
     const message = error instanceof Error ? error.message : String(error)
     return (
+      message.includes('COMPLETED_ITEM_NOT_FOUND') ||
+      message.includes('Item not found:') ||
       message.includes('LOCAL_FILES_MISSING') ||
       message.includes('LOCAL_PATH_OUTSIDE_ACTIVE_DOWNLOAD_ROOT')
     )

--- a/src/renderer/src/components/GamesView.tsx
+++ b/src/renderer/src/components/GamesView.tsx
@@ -16,7 +16,7 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import { useAdb } from '../hooks/useAdb'
 import { useGames } from '../hooks/useGames'
 import { useDownload } from '../hooks/useDownload'
-import { GameInfo } from '@shared/types'
+import { GameInfo, LocalLibraryIndex } from '@shared/types'
 import placeholderImage from '../assets/images/game-placeholder.png'
 import {
   Button,
@@ -58,7 +58,10 @@ import {
   FolderAddRegular,
   DocumentRegular,
   ChevronDownRegular,
-  CopyRegular
+  CopyRegular,
+  ArrowSort20Filled,
+  ArrowSortUpLines20Regular,
+  ArrowSortDownLines20Regular
 } from '@fluentui/react-icons'
 import { ArrowLeftRegular } from '@fluentui/react-icons'
 import GameDetailsDialog from './GameDetailsDialog'
@@ -86,8 +89,9 @@ const FIXED_COLUMNS_WIDTH =
   COLUMN_WIDTHS.LAST_UPDATED
 
 type FilterType = 'all' | 'installed' | 'downloaded' | 'update'
+type GamesTableRow = GameInfo & { isDownloadedLocal: boolean }
 
-const filterGameNameAndPackage: FilterFn<GameInfo> = (row, _columnId, filterValue) => {
+const filterGameNameAndPackage: FilterFn<GamesTableRow> = (row, _columnId, filterValue) => {
   const searchStr = String(filterValue).toLowerCase()
   const gameName = String(row.original.name ?? '').toLowerCase()
   const packageName = String(row.original.packageName ?? '').toLowerCase()
@@ -99,7 +103,7 @@ const filterGameNameAndPackage: FilterFn<GameInfo> = (row, _columnId, filterValu
   )
 }
 
-const booleanEqualsFilter: FilterFn<GameInfo> = (row, columnId, filterValue) => {
+const booleanEqualsFilter: FilterFn<GamesTableRow> = (row, columnId, filterValue) => {
   if (filterValue === undefined) return true
   return row.getValue(columnId) === filterValue
 }
@@ -141,7 +145,8 @@ const renderPopularityStars = (value: number): React.ReactNode => {
 
 declare module '@tanstack/react-table' {
   interface FilterFns {
-    gameNameAndPackageFilter: FilterFn<GameInfo>
+    gameNameAndPackageFilter: FilterFn<GamesTableRow>
+    booleanEquals: FilterFn<GamesTableRow>
   }
 }
 
@@ -311,6 +316,8 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [activeFilter, setActiveFilter] = useState<FilterType>('all')
+  const [excludeInstalled, setExcludeInstalled] = useState<boolean>(false)
+  const [excludeStoredLocal, setExcludeStoredLocal] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [dialogGame, setDialogGame] = useGameDialog()
   const [isDialogOpen, setIsDialogOpen] = useState<boolean>(false)
@@ -325,59 +332,140 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
   const [installSuccess, setInstallSuccess] = useState<boolean | null>(null)
   const [showObbConfirmDialog, setShowObbConfirmDialog] = useState<boolean>(false)
   const [obbFolderToConfirm, setObbFolderToConfirm] = useState<string | null>(null)
+  const [localLibraryIndex, setLocalLibraryIndex] = useState<LocalLibraryIndex>({
+    rootPath: '',
+    generatedAt: 0,
+    entries: []
+  })
 
   const downloadStatusMap = useMemo(() => {
-    const map = new Map<string, { status: string; progress: number }>()
+    const map = new Map<string, { status: string; progress: number; error?: string }>()
     downloadQueue.forEach((item) => {
       if (item.releaseName) {
         const progress =
           item.status === 'Extracting' ? (item.extractProgress ?? 0) : (item.progress ?? 0)
         map.set(item.releaseName, {
           status: item.status,
-          progress: progress
+          progress: progress,
+          error: item.error
         })
       }
     })
     return map
   }, [downloadQueue])
 
+  const localAvailability = useMemo(() => {
+    const releaseNames = new Set<string>()
+    const packageNames = new Set<string>()
+
+    for (const entry of localLibraryIndex.entries) {
+      if (entry.releaseName) {
+        releaseNames.add(entry.releaseName)
+      }
+      for (const packageName of entry.packageNames) {
+        packageNames.add(packageName)
+      }
+    }
+
+    return { releaseNames, packageNames }
+  }, [localLibraryIndex])
+
+  const isGameStoredLocally = useCallback(
+    (game: GameInfo): boolean => {
+      if (game.releaseName && localAvailability.releaseNames.has(game.releaseName)) {
+        return true
+      }
+      if (game.packageName && localAvailability.packageNames.has(game.packageName)) {
+        return true
+      }
+
+      return false
+    },
+    [localAvailability]
+  )
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadLocalLibrary = async (): Promise<void> => {
+      try {
+        const index = await window.api.localLibrary.getIndex()
+        if (isMounted) {
+          setLocalLibraryIndex(index)
+        }
+
+        // Force a fresh scan so manually added/removed files are reflected quickly.
+        const refreshedIndex = await window.api.localLibrary.rescan()
+        if (isMounted) {
+          setLocalLibraryIndex(refreshedIndex)
+        }
+      } catch (error) {
+        console.error('[GamesView] Failed to load local library index:', error)
+      }
+    }
+
+    const removeLocalLibraryUpdated = window.api.localLibrary.onUpdated((index) => {
+      setLocalLibraryIndex(index)
+    })
+
+    loadLocalLibrary()
+
+    return () => {
+      isMounted = false
+      removeLocalLibraryUpdated()
+    }
+  }, [])
+
   const counts = useMemo(() => {
     const total = games.length
     const installed = games.filter((g) => g.isInstalled).length
     const updates = games.filter((g) => g.hasUpdate).length
-    const downloaded = games.filter((g) => {
-      if (!g.releaseName || g.isInstalled) return false
-      return downloadStatusMap.get(g.releaseName)?.status === 'Completed'
-    }).length
+    const downloaded = games.filter((g) => !g.isInstalled && isGameStoredLocally(g)).length
     return { total, installed, downloaded, updates }
-  }, [games, downloadStatusMap])
+  }, [games, isGameStoredLocally])
+
+  const tableData = useMemo<GamesTableRow[]>(
+    () =>
+      games.map((game) => ({
+        ...game,
+        isDownloadedLocal: isGameStoredLocally(game)
+      })),
+    [games, isGameStoredLocally]
+  )
 
   useEffect(() => {
     setColumnFilters((prev) => {
       const otherFilters = prev.filter(
         (f) => f.id !== 'isInstalled' && f.id !== 'hasUpdate' && f.id !== 'isDownloaded'
       )
+      const nextFilters = [...otherFilters]
+
       switch (activeFilter) {
         case 'installed':
-          return [...otherFilters, { id: 'isInstalled', value: true }]
+          nextFilters.push({ id: 'isInstalled', value: true })
+          break
         case 'downloaded':
-          return [
-            ...otherFilters,
-            { id: 'isDownloaded', value: true },
-            { id: 'isInstalled', value: false }
-          ]
+          nextFilters.push({ id: 'isDownloaded', value: true }, { id: 'isInstalled', value: false })
+          break
         case 'update':
-          return [
-            ...otherFilters,
-            { id: 'isInstalled', value: true },
-            { id: 'hasUpdate', value: true }
-          ]
+          nextFilters.push({ id: 'isInstalled', value: true }, { id: 'hasUpdate', value: true })
+          break
         case 'all':
         default:
-          return otherFilters
+          break
       }
+
+      // Optional exclusions (icon toggles) when they don't conflict with a strict active filter.
+      if (excludeInstalled && activeFilter !== 'installed' && activeFilter !== 'update') {
+        nextFilters.push({ id: 'isInstalled', value: false })
+      }
+      if (excludeStoredLocal && activeFilter !== 'downloaded') {
+        nextFilters.push({ id: 'isDownloaded', value: false })
+      }
+
+      return nextFilters
     })
-  }, [activeFilter])
+  }, [activeFilter, excludeInstalled, excludeStoredLocal])
 
   useEffect(() => {
     const unsubscribe = window.api.adb.onInstallationCompleted((deviceId) => {
@@ -436,7 +524,7 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
     }
   }, [])
 
-  const columns = useMemo<ColumnDef<GameInfo>[]>(() => {
+  const columns = useMemo<ColumnDef<GamesTableRow>[]>(() => {
     // Calculate dynamic width for name column, with a minimum width
     const nameColumnWidth = Math.max(
       COLUMN_WIDTHS.MIN_NAME_PACKAGE,
@@ -446,16 +534,54 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
     return [
       {
         id: 'downloadStatus',
-        header: '',
+        header: () => (
+          <div className="status-header-filters">
+            <Tooltip
+              content={
+                excludeStoredLocal ? 'Stored local items are hidden' : 'Stored local items are visible'
+              }
+              relationship="label"
+            >
+              <button
+                type="button"
+                className={`status-filter-toggle ${excludeStoredLocal ? 'excluded' : ''}`}
+                onClick={() => setExcludeStoredLocal((value) => !value)}
+                aria-pressed={excludeStoredLocal}
+                aria-label="Toggle stored local filter"
+              >
+                <span className="status-filter-icon-wrap">
+                  <DesktopRegular fontSize={16} color={tokens.colorNeutralForeground2} aria-hidden />
+                </span>
+              </button>
+            </Tooltip>
+            <Tooltip
+              content={excludeInstalled ? 'Installed items are hidden' : 'Installed items are visible'}
+              relationship="label"
+            >
+              <button
+                type="button"
+                className={`status-filter-toggle ${excludeInstalled ? 'excluded' : ''}`}
+                onClick={() => setExcludeInstalled((value) => !value)}
+                aria-pressed={excludeInstalled}
+                aria-label="Toggle installed filter"
+              >
+                <span className="status-filter-icon-wrap">
+                  <CheckmarkCircleRegular
+                    fontSize={16}
+                    color={tokens.colorPaletteGreenForeground1}
+                    aria-hidden
+                  />
+                </span>
+              </button>
+            </Tooltip>
+          </div>
+        ),
         size: COLUMN_WIDTHS.STATUS,
         enableResizing: false,
         enableSorting: false,
         cell: ({ row }) => {
           const game = row.original
-          const downloadInfo = game.releaseName
-            ? downloadStatusMap.get(game.releaseName)
-            : undefined
-          const isDownloaded = downloadInfo?.status === 'Completed'
+          const isDownloaded = game.isDownloadedLocal
           const isInstalled = game.isInstalled
           const isUpdateAvailable = game.hasUpdate
 
@@ -571,9 +697,16 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
                   </div>
                 )}
                 {isInstallError && (
-                  <Badge shape="rounded" color="danger" appearance="outline">
-                    Install Error
-                  </Badge>
+                  <Tooltip
+                    content={downloadInfo?.error || 'Installation failed. Check logs for details.'}
+                    relationship="label"
+                  >
+                    <span>
+                      <Badge shape="rounded" color="danger" appearance="outline">
+                        Install Error
+                      </Badge>
+                    </span>
+                  </Tooltip>
                 )}
               </div>
               {(isDownloading || isExtracting || isInstalling) && downloadInfo && (
@@ -652,18 +785,21 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
       {
         id: 'isDownloaded',
         header: 'Downloaded Status',
-        accessorFn: (row) => {
-          if (!row.releaseName) return false
-          return downloadStatusMap.get(row.releaseName)?.status === 'Completed'
-        },
+        accessorKey: 'isDownloadedLocal',
         enableResizing: false,
         filterFn: 'booleanEquals'
       }
     ]
-  }, [downloadStatusMap, styles, tableWidth])
+  }, [
+    downloadStatusMap,
+    excludeInstalled,
+    excludeStoredLocal,
+    styles,
+    tableWidth
+  ])
 
-  const table = useReactTable({
-    data: games,
+  const table = useReactTable<GamesTableRow>({
+    data: tableData,
     columns,
     columnResizeMode: 'onChange',
     filterFns: {
@@ -728,7 +864,7 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
 
   const handleRowClick = (
     _event: React.MouseEvent<HTMLTableRowElement>,
-    row: Row<GameInfo>
+    row: Row<GamesTableRow>
   ): void => {
     console.log('Row clicked for game:', row.original.name)
     setDialogGame(row.original)
@@ -762,6 +898,59 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
       .catch((err) => {
         console.error('Error adding to queue:', err)
       })
+  }
+
+  const handleRedownload = (game: GameInfo): void => {
+    if (!game) return
+    console.log(`Re-download action triggered for: ${game.packageName}`)
+    addDownloadToQueue(game, { skipInstall: true, forceRequeueCompleted: true })
+      .then((success) => {
+        if (success) {
+          console.log(
+            `Successfully added ${game.releaseName} to download queue (skip auto-install).`
+          )
+        } else {
+          console.log(`Failed to add ${game.releaseName} to queue (might already exist).`)
+        }
+      })
+      .catch((err) => {
+        console.error('Error adding to queue for re-download:', err)
+      })
+  }
+
+  const handleDownloadOnly = (game: GameInfo): void => {
+    if (!game) return
+    console.log(`Download-only action triggered for: ${game.packageName}`)
+    addDownloadToQueue(game, { skipInstall: true, forceRequeueCompleted: true })
+      .then((success) => {
+        if (success) {
+          console.log(`Successfully added ${game.releaseName} to download queue (download-only).`)
+        } else {
+          console.log(`Failed to add ${game.releaseName} to queue (might already exist).`)
+        }
+      })
+      .catch((err) => {
+        console.error('Error adding to queue for download-only:', err)
+      })
+  }
+
+  const shouldFallbackToRedownload = (error: unknown): boolean => {
+    const message = error instanceof Error ? error.message : String(error)
+    return (
+      message.includes('LOCAL_FILES_MISSING') ||
+      message.includes('LOCAL_PATH_OUTSIDE_ACTIVE_DOWNLOAD_ROOT')
+    )
+  }
+
+  const queueForRedownload = async (game: GameInfo, context: string): Promise<boolean> => {
+    console.log(`${context}: Queuing re-download for ${game.releaseName}.`)
+    const addToQueueSuccess = await addDownloadToQueue(game, {
+      forceRequeueCompleted: true
+    })
+    if (!addToQueueSuccess) {
+      console.warn(`${context}: Failed to queue ${game.releaseName} for re-download.`)
+    }
+    return addToQueueSuccess
   }
 
   const handleUninstall = async (game: GameInfo): Promise<void> => {
@@ -828,24 +1017,37 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
         // The game is now uninstalled from the device.
         // Downloaded files (if any) should still be present.
 
-        const downloadInfo = downloadStatusMap.get(game.releaseName)
+        const hasLocalFiles = isGameStoredLocally(game)
 
-        if (downloadInfo?.status === 'Completed') {
+        if (hasLocalFiles) {
           console.log(
-            `Reinstall: Files for ${game.releaseName} are 'Completed'. Initiating install from completed.`
+            `Reinstall: Local files found for ${game.releaseName}. Initiating install from completed.`
           )
-          await window.api.downloads.installFromCompleted(game.releaseName, selectedDevice)
-          console.log(`Reinstall: 'installFromCompleted' called for ${game.releaseName}.`)
+          try {
+            await window.api.downloads.installFromCompleted(game.releaseName, selectedDevice)
+            console.log(`Reinstall: 'installFromCompleted' called for ${game.releaseName}.`)
+          } catch (installError) {
+            if (shouldFallbackToRedownload(installError)) {
+              const queued = await queueForRedownload(game, 'Reinstall')
+              if (!queued) {
+                window.alert(
+                  `Reinstall for ${game.name} failed: Could not queue re-download. Please check logs.`
+                )
+              }
+            } else {
+              throw installError
+            }
+          }
         } else {
           console.log(
-            `Reinstall: Files for ${game.releaseName} not 'Completed' (status: ${downloadInfo?.status}). Adding to download queue.`
+            `Reinstall: Local files not found for ${game.releaseName}. Adding to download queue.`
           )
-          const addToQueueSuccess = await addDownloadToQueue(game)
+          const addToQueueSuccess = await queueForRedownload(game, 'Reinstall')
           if (addToQueueSuccess) {
             console.log(`Reinstall: Successfully added ${game.releaseName} to download queue.`)
           } else {
             console.warn(
-              `Reinstall: Failed to add ${game.releaseName} to queue. Current status: ${downloadInfo?.status}.`
+              `Reinstall: Failed to add ${game.releaseName} to queue.`
             )
             window.alert(
               `Reinstall for ${game.name} failed: Could not add to download queue. Please check logs.`
@@ -890,26 +1092,39 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
     )
 
     try {
-      const downloadInfo = downloadStatusMap.get(game.releaseName)
+      const hasLocalFiles = isGameStoredLocally(game)
 
-      if (downloadInfo?.status === 'Completed') {
+      if (hasLocalFiles) {
         console.log(
-          `Update for ${game.releaseName}: Files are already 'Completed'. Initiating install from completed.`
+          `Update for ${game.releaseName}: Local files found. Initiating install from completed.`
         )
-        await window.api.downloads.installFromCompleted(game.releaseName, selectedDevice)
-        console.log(`Update: 'installFromCompleted' called for ${game.releaseName}.`)
+        try {
+          await window.api.downloads.installFromCompleted(game.releaseName, selectedDevice)
+          console.log(`Update: 'installFromCompleted' called for ${game.releaseName}.`)
+        } catch (installError) {
+          if (shouldFallbackToRedownload(installError)) {
+            const queued = await queueForRedownload(game, 'Update')
+            if (!queued) {
+              window.alert(
+                `Could not queue ${game.name} for re-download. It might already be in the queue or an error occurred.`
+              )
+            }
+          } else {
+            throw installError
+          }
+        }
         // Optionally, refresh packages or rely on 'installation-completed' event
         // loadPackages().catch(err => console.error('Update: Error refreshing packages post-install:', err));
       } else {
         console.log(
-          `Update for ${game.releaseName}: Files not 'Completed' (status: ${downloadInfo?.status}). Adding to download queue.`
+          `Update for ${game.releaseName}: Local files not found. Adding to download queue.`
         )
-        const addToQueueSuccess = await addDownloadToQueue(game)
+        const addToQueueSuccess = await queueForRedownload(game, 'Update')
         if (addToQueueSuccess) {
           console.log(`Update: Successfully added ${game.releaseName} to download queue.`)
         } else {
           console.warn(
-            `Update: Failed to add ${game.releaseName} to queue. Current status: ${downloadInfo?.status}.`
+            `Update: Failed to add ${game.releaseName} to queue.`
           )
           window.alert(
             `Could not queue ${game.name} for update. It might already be in the queue or an error occurred. Please check logs.`
@@ -936,17 +1151,26 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
     cancelDownload(game.releaseName)
   }
 
-  const handleInstallFromCompleted = (game: GameInfo): void => {
+  const handleInstallFromCompleted = async (game: GameInfo): Promise<void> => {
     if (!game || !game.releaseName || !selectedDevice) {
       console.error('Missing game, releaseName, or deviceId for install from completed action')
       window.alert('Cannot start installation: Missing required information.')
       return
     }
     console.log(`Requesting install from completed for ${game.releaseName} on ${selectedDevice}`)
-    window.api.downloads.installFromCompleted(game.releaseName, selectedDevice).catch((err) => {
+    try {
+      await window.api.downloads.installFromCompleted(game.releaseName, selectedDevice)
+    } catch (err) {
+      if (shouldFallbackToRedownload(err)) {
+        const queued = await queueForRedownload(game, 'InstallFromCompleted')
+        if (!queued) {
+          window.alert('Failed to queue re-download. Please check the main process logs.')
+        }
+        return
+      }
       console.error('Error triggering install from completed:', err)
       window.alert('Failed to start installation. Please check the main process logs.')
-    })
+    }
   }
 
   const handleDeleteDownloaded = useCallback(
@@ -1369,7 +1593,10 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
                   All ({counts.total})
                 </button>
                 <button
-                  onClick={() => setActiveFilter('installed')}
+                  onClick={() => {
+                    setExcludeInstalled(false)
+                    setActiveFilter('installed')
+                  }}
                   className={activeFilter === 'installed' ? 'active' : ''}
                 >
                   <span
@@ -1397,7 +1624,10 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
                   </span>
                 </button>
                 <button
-                  onClick={() => setActiveFilter('downloaded')}
+                  onClick={() => {
+                    setExcludeStoredLocal(false)
+                    setActiveFilter('downloaded')
+                  }}
                   className={activeFilter === 'downloaded' ? 'active' : ''}
                   disabled={counts.downloaded === 0}
                 >
@@ -1426,7 +1656,10 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
                   </span>
                 </button>
                 <button
-                  onClick={() => setActiveFilter('update')}
+                  onClick={() => {
+                    setExcludeInstalled(false)
+                    setActiveFilter('update')
+                  }}
                   className={activeFilter === 'update' ? 'active' : ''}
                   disabled={counts.updates === 0}
                 >
@@ -1497,11 +1730,44 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
                                 onClick: header.column.getToggleSortingHandler()
                               }}
                             >
-                              {flexRender(header.column.columnDef.header, header.getContext())}
-                              {{
-                                asc: ' 🔼',
-                                desc: ' 🔽'
-                              }[header.column.getIsSorted() as string] ?? null}
+                              <span
+                                style={{
+                                  display: 'inline-flex',
+                                  alignItems: 'center',
+                                  gap: tokens.spacingHorizontalXS
+                                }}
+                              >
+                                {flexRender(header.column.columnDef.header, header.getContext())}
+                                {(() => {
+                                  const sortState = header.column.getIsSorted()
+                                  if (sortState === 'asc') {
+                                    return (
+                                      <ArrowSortUpLines20Regular
+                                        fontSize={16}
+                                        color={tokens.colorPaletteGreenForeground1}
+                                      />
+                                    )
+                                  }
+                                  if (sortState === 'desc') {
+                                    return (
+                                      <ArrowSortDownLines20Regular
+                                        fontSize={16}
+                                        color={tokens.colorPaletteRedForeground1}
+                                      />
+                                    )
+                                  }
+                                  if (header.column.getCanSort()) {
+                                    return (
+                                      <ArrowSort20Filled
+                                        fontSize={16}
+                                        color={tokens.colorNeutralForeground3}
+                                        style={{ opacity: 0.55 }}
+                                      />
+                                    )
+                                  }
+                                  return null
+                                })()}
+                              </span>
                             </div>
                           )}
                           {header.column.getCanResize() && (
@@ -1520,7 +1786,7 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
                   style={{ height: `${rowVirtualizer.getTotalSize()}px`, position: 'relative' }}
                 >
                   {rowVirtualizer.getVirtualItems().map((virtualRow) => {
-                    const row = rows[virtualRow.index] as Row<GameInfo>
+                    const row = rows[virtualRow.index] as Row<GamesTableRow>
                     const rowClasses = [
                       row.original.isInstalled ? 'row-installed' : 'row-not-installed',
                       row.original.hasUpdate ? 'row-update-available' : ''
@@ -1566,7 +1832,10 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices }) => {
                 open={isDialogOpen}
                 onClose={handleCloseDialog}
                 downloadStatusMap={downloadStatusMap}
+                isStoredLocally={dialogGame ? isGameStoredLocally(dialogGame) : false}
                 onInstall={handleInstall}
+                onDownloadOnly={handleDownloadOnly}
+                onRedownload={handleRedownload}
                 onUninstall={handleUninstall}
                 onReinstall={handleReinstall}
                 onUpdate={handleUpdate}

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useCallback } from 'react'
 import {
   Card,
   CardHeader,
@@ -30,6 +30,7 @@ import {
 import { useSettings } from '../hooks/useSettings'
 import { useGames } from '../hooks/useGames'
 import { useLogs } from '../hooks/useLogs'
+import { FuseStatus } from '@shared/types'
 
 // Supported speed units with conversion factors to KB/s
 const SPEED_UNITS = [
@@ -408,6 +409,9 @@ const Settings: React.FC = () => {
 
   const [localError, setLocalError] = useState<string | null>(null)
   const [saveSuccess, setSaveSuccess] = useState(false)
+  const [fuseStatus, setFuseStatus] = useState<FuseStatus | null>(null)
+  const [isCheckingFuse, setIsCheckingFuse] = useState(false)
+  const [fuseActionError, setFuseActionError] = useState<string | null>(null)
 
   // Update local state when the context values change
   useEffect(() => {
@@ -672,6 +676,52 @@ const Settings: React.FC = () => {
     }
   }
 
+  const refreshFuseStatus = useCallback(async (): Promise<void> => {
+    try {
+      setIsCheckingFuse(true)
+      setFuseActionError(null)
+      const status = await window.api.settings.getFuseStatus()
+      setFuseStatus(status)
+    } catch (err) {
+      console.error('Error checking FUSE status:', err)
+      setFuseActionError('Failed to check FUSE status')
+    } finally {
+      setIsCheckingFuse(false)
+    }
+  }, [])
+
+  const handleOpenFuseInstaller = async (): Promise<void> => {
+    try {
+      setFuseActionError(null)
+      const opened = await window.api.settings.openFuseInstaller()
+      if (!opened) {
+        setFuseActionError('FUSE installer is not available for this platform.')
+      }
+    } catch (err) {
+      console.error('Error opening FUSE installer page:', err)
+      setFuseActionError('Failed to open FUSE installer page')
+    }
+  }
+
+  const handleOpenFuseRemovalGuide = async (): Promise<void> => {
+    try {
+      setFuseActionError(null)
+      const opened = await window.api.settings.openFuseRemovalGuide()
+      if (!opened) {
+        setFuseActionError('FUSE removal guidance is not available for this platform.')
+      }
+    } catch (err) {
+      console.error('Error opening FUSE removal guidance:', err)
+      setFuseActionError('Failed to open FUSE removal guidance')
+    }
+  }
+
+  useEffect(() => {
+    refreshFuseStatus().catch((err) => {
+      console.error('Initial FUSE status check failed:', err)
+    })
+  }, [refreshFuseStatus])
+
   return (
     <div className={styles.root}>
       <div className={styles.contentContainer}>
@@ -800,6 +850,55 @@ const Settings: React.FC = () => {
                 Settings saved successfully
               </Text>
             )}
+          </div>
+        </Card>
+
+        <Card className={styles.card}>
+          <CardHeader description={<Subtitle1 weight="semibold">FUSE (Mount Support)</Subtitle1>} />
+          <div className={styles.cardContent}>
+            <Text>
+              Mount-based downloads work best when FUSE is installed. If unavailable, the app falls
+              back to direct downloads.
+            </Text>
+
+            <div className={styles.formRow}>
+              {isCheckingFuse ? (
+                <Spinner size="small" label="Checking FUSE status..." />
+              ) : (
+                <Text>
+                  {fuseStatus?.available ? 'FUSE available' : 'FUSE not available'} -{' '}
+                  {fuseStatus?.message ?? 'Status unknown'}
+                </Text>
+              )}
+            </div>
+
+            {fuseStatus?.detectedBy && (
+              <Text className={styles.hint}>
+                <InfoRegular />
+                Detected via: {fuseStatus.detectedBy}
+              </Text>
+            )}
+
+            <div
+              className={styles.formRow}
+              style={{ justifyContent: 'flex-end', marginTop: tokens.spacingVerticalM }}
+            >
+              <Button appearance="secondary" onClick={() => refreshFuseStatus()}>
+                Check Again
+              </Button>
+              {!fuseStatus?.available && fuseStatus?.installable && (
+                <Button appearance="primary" onClick={handleOpenFuseInstaller}>
+                  Install FUSE
+                </Button>
+              )}
+              {fuseStatus?.available && fuseStatus?.installable && (
+                <Button appearance="secondary" onClick={handleOpenFuseRemovalGuide}>
+                  Remove FUSE
+                </Button>
+              )}
+            </div>
+
+            {fuseActionError && <Text className={styles.error}>{fuseActionError}</Text>}
           </div>
         </Card>
 

--- a/src/renderer/src/context/DownloadContext.ts
+++ b/src/renderer/src/context/DownloadContext.ts
@@ -1,11 +1,11 @@
 import { createContext } from 'react'
-import { DownloadItem, GameInfo } from '@shared/types'
+import { DownloadAddOptions, DownloadItem, GameInfo } from '@shared/types'
 
 export interface DownloadContextType {
   queue: DownloadItem[]
   isLoading: boolean
   error: string | null
-  addToQueue: (game: GameInfo) => Promise<boolean>
+  addToQueue: (game: GameInfo, options?: DownloadAddOptions) => Promise<boolean>
   removeFromQueue: (releaseName: string) => Promise<void>
   cancelDownload: (releaseName: string) => void
   retryDownload: (releaseName: string) => void

--- a/src/renderer/src/context/DownloadProvider.tsx
+++ b/src/renderer/src/context/DownloadProvider.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useEffect, useState, useCallback } from 'react'
 import { DownloadContext, DownloadContextType } from './DownloadContext'
-import { DownloadItem, GameInfo } from '@shared/types'
+import { DownloadAddOptions, DownloadItem, GameInfo } from '@shared/types'
 
 interface DownloadProviderProps {
   children: ReactNode
@@ -46,10 +46,10 @@ export const DownloadProvider: React.FC<DownloadProviderProps> = ({ children }) 
     }
   }, [])
 
-  const addToQueue = useCallback(async (game: GameInfo): Promise<boolean> => {
+  const addToQueue = useCallback(async (game: GameInfo, options?: DownloadAddOptions): Promise<boolean> => {
     console.log(`Context: Adding ${game.releaseName} to queue...`)
     try {
-      const success = await window.api.downloads.addToQueue(game)
+      const success = await window.api.downloads.addToQueue(game, options)
       if (!success) {
         console.warn(
           `Context: Failed to add ${game.releaseName} to queue (likely already present).`

--- a/src/renderer/src/context/GamesProvider.tsx
+++ b/src/renderer/src/context/GamesProvider.tsx
@@ -156,6 +156,15 @@ export const GamesProvider: React.FC<GamesProviderProps> = ({ children }) => {
 
   // enrich the games with the installed packages and the device version codes
   const games = useMemo((): GameInfo[] => {
+    if (!isDeviceConnected) {
+      return rawGames.map((game) => ({
+        ...game,
+        isInstalled: false,
+        deviceVersionCode: undefined,
+        hasUpdate: false
+      }))
+    }
+
     const installedSet = new Set(installedPackages.map((pkg) => pkg.packageName))
 
     return rawGames.map((game) => {
@@ -185,7 +194,7 @@ export const GamesProvider: React.FC<GamesProviderProps> = ({ children }) => {
         hasUpdate
       }
     })
-  }, [rawGames, installedPackages])
+  }, [rawGames, installedPackages, isDeviceConnected])
 
   const localGames = useMemo((): GameInfo[] => {
     return installedPackages.map((game) => ({

--- a/src/renderer/src/electron-api.d.ts
+++ b/src/renderer/src/electron-api.d.ts
@@ -10,7 +10,8 @@ import {
   DependencyAPIRenderer,
   LogsAPIRenderer,
   MirrorAPIRenderer,
-  WiFiBookmark
+  WiFiBookmark,
+  LocalLibraryAPIRenderer
 } from '@shared/types'
 
 declare global {
@@ -26,6 +27,7 @@ declare global {
       updates: UpdateAPIRenderer
       logs: LogsAPIRenderer
       mirrors: MirrorAPIRenderer
+      localLibrary: LocalLibraryAPIRenderer
       dialog: {
         showDirectoryPicker: () => Promise<string | null>
         showFilePicker: (options?: {

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -350,6 +350,15 @@ export interface Settings {
   colorScheme: 'light' | 'dark'
 }
 
+export interface FuseStatus {
+  supported: boolean
+  available: boolean
+  installable: boolean
+  platform: NodeJS.Platform
+  message: string
+  detectedBy?: string
+}
+
 export interface SettingsAPI {
   getDownloadPath: () => string
   setDownloadPath: (path: string) => void
@@ -374,7 +383,11 @@ export interface SettingsAPIRenderer
       getColorScheme: () => Promise<'light' | 'dark'>
       setColorScheme: (scheme: 'light' | 'dark') => Promise<void>
     }
-  > {}
+  > {
+  getFuseStatus: () => Promise<FuseStatus>
+  openFuseInstaller: () => Promise<boolean>
+  openFuseRemovalGuide: () => Promise<boolean>
+}
 
 // Logs API
 export interface LogsAPI {

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -141,12 +141,36 @@ export interface DownloadItem {
   eta?: string
   extractProgress?: number
   size?: string
+  // If true, download/extract completes but auto-install step is skipped.
+  skipInstall?: boolean
+}
+
+export interface DownloadAddOptions {
+  skipInstall?: boolean
+  forceRequeueCompleted?: boolean
 }
 
 export interface DownloadProgress {
   packageName: string
   stage: 'download' | 'extract' | 'copy' | 'install'
   progress: number
+}
+
+export interface LocalLibraryEntry {
+  id: string
+  releaseName: string
+  path: string
+  source: 'folder' | 'apk-file'
+  apkCount: number
+  hasInstallScript: boolean
+  packageNames: string[]
+  lastSeen: number
+}
+
+export interface LocalLibraryIndex {
+  rootPath: string
+  generatedAt: number
+  entries: LocalLibraryEntry[]
 }
 
 // Update types
@@ -254,7 +278,7 @@ export interface GameAPIRenderer
 
 export interface DownloadAPI {
   getQueue: () => Promise<DownloadItem[]>
-  addToQueue: (game: GameInfo) => Promise<boolean>
+  addToQueue: (game: GameInfo, options?: DownloadAddOptions) => Promise<boolean>
   removeFromQueue: (releaseName: string) => Promise<void>
   cancelUserRequest: (releaseName: string) => void
   retryDownload: (releaseName: string) => void
@@ -270,6 +294,15 @@ export interface DownloadAPIRenderer extends DownloadAPI {
   installFromCompleted: (releaseName: string, deviceId: string) => Promise<void>
   installManualFile: (filePath: string, deviceId: string) => Promise<boolean>
   copyObbFolder: (folderPath: string, deviceId: string) => Promise<boolean>
+}
+
+export interface LocalLibraryAPI {
+  getIndex: () => Promise<LocalLibraryIndex>
+  rescan: () => Promise<LocalLibraryIndex>
+}
+
+export interface LocalLibraryAPIRenderer extends LocalLibraryAPI {
+  onUpdated: (callback: (index: LocalLibraryIndex) => void) => () => void
 }
 
 export interface UploadAPI {

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -13,7 +13,8 @@ import {
   Mirror,
   MirrorTestResult,
   WiFiBookmark,
-  LocalLibraryIndex
+  LocalLibraryIndex,
+  FuseStatus
 } from './index'
 
 // Define types for all IPC channels between renderer and main
@@ -96,6 +97,9 @@ export interface IPCChannels {
   'settings:set-upload-speed-limit': DefineChannel<[limit: number], void>
   'settings:get-color-scheme': DefineChannel<[], 'light' | 'dark'>
   'settings:set-color-scheme': DefineChannel<[scheme: 'light' | 'dark'], void>
+  'settings:get-fuse-status': DefineChannel<[], FuseStatus>
+  'settings:open-fuse-installer': DefineChannel<[], boolean>
+  'settings:open-fuse-removal-guide': DefineChannel<[], boolean>
 
   // Log upload related channels
   'logs:upload-current': DefineChannel<[], { url: string; password: string } | null>

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -12,7 +12,8 @@ import {
   BlacklistEntry,
   Mirror,
   MirrorTestResult,
-  WiFiBookmark
+  WiFiBookmark,
+  LocalLibraryIndex
 } from './index'
 
 // Define types for all IPC channels between renderer and main
@@ -62,10 +63,15 @@ export interface IPCChannels {
 
   // Download related channels
   'download:get-queue': DefineChannel<[], DownloadItem[]>
-  'download:add': DefineChannel<[game: GameInfo], boolean>
+  'download:add': DefineChannel<
+    [game: GameInfo, options?: { skipInstall?: boolean; forceRequeueCompleted?: boolean }],
+    boolean
+  >
   'download:remove': DefineChannel<[releaseName: string], void>
   'download:delete-files': DefineChannel<[releaseName: string], boolean>
   'download:install-from-completed': DefineChannel<[releaseName: string, deviceId: string], void>
+  'local-library:get-index': DefineChannel<[], LocalLibraryIndex>
+  'local-library:rescan': DefineChannel<[], LocalLibraryIndex>
 
   // Upload related channels
   'upload:prepare': DefineChannel<
@@ -165,4 +171,5 @@ export interface IPCEvents {
   'update:update-downloaded': [updateInfo: UpdateInfo]
   'mirrors:test-progress': [id: string, status: 'testing' | 'success' | 'failed', error?: string]
   'mirrors:mirrors-updated': [mirrors: Mirror[]]
+  'local-library:updated': [index: LocalLibraryIndex]
 }


### PR DESCRIPTION
# v.1.3.6

- Fix download progress display for direct HTTP downloads by parsing rclone stats output.
- Add “Ready to Install” filter (stored locally, not installed) with icons and tooltips.
- Keep toolbar controls and status text on a single line; set minimum window width to 1250px.
- Update popularity display to 5‑star ratings with half‑stars.
- Ensure Installed filter reflects actual device installs only.

<img width="1368" height="450" alt="CleanShot 2026-02-06 at 18 46 27@2x" src="https://github.com/user-attachments/assets/409ccc09-963e-4c92-92ac-8b6ded861575" />

<img width="2486" height="1184" alt="CleanShot 2026-02-06 at 18 46 58@2x" src="https://github.com/user-attachments/assets/b62ac6c0-1049-4c44-99f3-68964d4dbac3" />

<img width="2482" height="488" alt="CleanShot 2026-02-06 at 18 47 33@2x" src="https://github.com/user-attachments/assets/79c4bd9b-dc48-486e-a838-b004e8b111cf" />


# v.1.3.5
was an intermediate build fixing URL and improve trailer fallback UI with thumbnail + YouTube logo and clearer messaging.